### PR TITLE
Fix yarn warnings when running yarn install

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+workspaces-experimental false

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   "devDependencies": {
     "@chakra-ui/icons": "^2.1.1",
     "@chakra-ui/react": "^2.8.1",
+    "@chakra-ui/styled-system": "^2.9.1",
+    "@chakra-ui/system": "^2.6.1",
     "@chakra-ui/theme-tools": "^2.1.1",
     "@electron/rebuild": "^3.3.0",
     "@emotion/react": "^11.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1664,7 +1664,7 @@
     "@chakra-ui/react-context" "2.1.0"
     "@chakra-ui/shared-utils" "2.0.5"
 
-"@chakra-ui/styled-system@2.9.1":
+"@chakra-ui/styled-system@2.9.1", "@chakra-ui/styled-system@^2.9.1":
   version "2.9.1"
   resolved "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.1.tgz#888a4901b2afa174461259a8875379adb0363934"
   integrity sha512-jhYKBLxwOPi9/bQt9kqV3ELa/4CjmNNruTyXlPp5M0v0+pDMUngPp48mVLoskm9RKZGE0h1qpvj/jZ3K7c7t8w==
@@ -1681,7 +1681,7 @@
     "@chakra-ui/checkbox" "2.3.1"
     "@chakra-ui/shared-utils" "2.0.5"
 
-"@chakra-ui/system@2.6.1":
+"@chakra-ui/system@2.6.1", "@chakra-ui/system@^2.6.1":
   version "2.6.1"
   resolved "https://registry.npmjs.org/@chakra-ui/system/-/system-2.6.1.tgz#22ee50ddc9e1f56b974a0dd42d86108391a2f372"
   integrity sha512-P5Q/XRWy3f1pXJ7IxDkV+Z6AT7GJeR2JlBnQl109xewVQcBLWWMIp702fFMFw8KZ2ALB/aYKtWm5EmQMddC/tg==


### PR DESCRIPTION
When running yarn install, I ran into a few yarn warnings about peer dependencies and about using workspaces in dependent packages, so here's a fix for those!