### PR TITLE
Fix a bug with fetching custom assets for a non-default account

### DIFF
--- a/main/api/transactions/handleGetTransactions.ts
+++ b/main/api/transactions/handleGetTransactions.ts
@@ -19,5 +19,5 @@ export async function handleGetTransactions({ accountName }: Params) {
     transactionsStream.contentStream(),
   );
 
-  return formatTransactionsToNotes(rpcClient, transactions);
+  return formatTransactionsToNotes(rpcClient, transactions, accountName);
 }

--- a/main/api/transactions/utils/formatTransactionsToNotes.ts
+++ b/main/api/transactions/utils/formatTransactionsToNotes.ts
@@ -10,10 +10,11 @@ import { IRON_ID } from "../../../../shared/constants";
 export async function createAssetLookup(
   client: RpcClient,
   assetIds: string[],
+  accountName: string,
 ): Promise<{ [key: string]: RpcAsset }> {
   assetIds = [...new Set(assetIds)];
   const assets = await Promise.all(
-    assetIds.map((id) => client.wallet.getAsset({ id })),
+    assetIds.map((id) => client.wallet.getAsset({ id, account: accountName })),
   );
   return Object.fromEntries(
     assets.map((asset) => [asset.content.id, asset.content]),
@@ -34,11 +35,16 @@ export type TransactionNote = {
 export async function formatTransactionsToNotes(
   client: RpcClient,
   transactions: RpcWalletTransaction[],
+  accountName: string,
 ): Promise<TransactionNote[]> {
   const transactionAssetIds = transactions.flatMap((tx) => {
     return tx.notes?.map((note) => note.assetId) ?? [];
   });
-  const assetLookup = await createAssetLookup(client, transactionAssetIds);
+  const assetLookup = await createAssetLookup(
+    client,
+    transactionAssetIds,
+    accountName,
+  );
 
   const transactionNotes: Array<TransactionNote> = [];
 


### PR DESCRIPTION
Fixes fetching transactions when the account is not the default account and when the account contains custom assets that aren't in the default account.

We had a similar bug in the ironfish CLI: https://github.com/iron-fish/ironfish/pull/4358