### PR TITLE
Add V1 address book code

### DIFF
--- a/main/api/address-book/v1/AbstractStorage.ts
+++ b/main/api/address-book/v1/AbstractStorage.ts
@@ -1,0 +1,96 @@
+import NeDBStorage from "nedb";
+
+import Entity from "./Entity";
+import IStorage from "./IStorage";
+import SortType from "./SortType";
+
+abstract class AbstractStorage<T extends Entity> implements IStorage<T> {
+  protected storage: Nedb;
+
+  constructor(
+    storageOptions: Nedb.DataStoreOptions,
+    indexes: Nedb.EnsureIndexOptions[],
+  ) {
+    this.storage = new NeDBStorage(storageOptions);
+    indexes.forEach((opts) => {
+      this.storage.ensureIndex(opts);
+    });
+  }
+  abstract list(searchTerm: string, sort: SortType): Promise<T[]>;
+  get(identity: string): Promise<T> {
+    return new Promise((resolve, reject) => {
+      this.storage.findOne({ _id: identity }, (err, entity) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(entity);
+        }
+      });
+    });
+  }
+
+  add(entity: Partial<Omit<T, "_id">>): Promise<T> {
+    return new Promise((resolve, reject) => {
+      this.storage.insert(entity, (err, result) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result as T);
+        }
+      });
+    });
+  }
+
+  update(
+    identity: string,
+    fieldsToUpdate: Partial<Omit<T, "_id">>,
+  ): Promise<T> {
+    return new Promise((resolve, reject) => {
+      this.storage.update(
+        { _id: identity },
+        { $set: fieldsToUpdate },
+        { returnUpdatedDocs: true, upsert: true },
+        (err) => {
+          if (err) {
+            reject(err);
+          } else {
+            this.get(identity).then((res) => resolve(res));
+          }
+        },
+      );
+    });
+  }
+
+  delete(identity: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.storage.remove({ _id: identity }, {}, (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  find(entity: Partial<Omit<T, "_id">>): Promise<T> {
+    return new Promise((resolve, reject) => {
+      this.storage.findOne(
+        {
+          $or: Object.entries(entity).map((key_value) => ({
+            [key_value[0]]: key_value[1],
+          })),
+        },
+        (err, contact) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(contact);
+          }
+        },
+      );
+    });
+  }
+}
+
+export default AbstractStorage;

--- a/main/api/address-book/v1/AddressBookStorage.ts
+++ b/main/api/address-book/v1/AddressBookStorage.ts
@@ -1,0 +1,101 @@
+import os from "os";
+import path from "path";
+
+import AbstractStorage from "./AbstractStorage";
+import Contact from "./Contact";
+import SortType from "./SortType";
+
+const getAppHomeFolder = (...paths: string[]) => {
+  return path.join(os.homedir(), "/.ironfish/node-app", ...paths);
+};
+
+export const ADDRESS_BOOK_STORAGE_NAME = "address_book.db";
+
+export class AddressBookStorage extends AbstractStorage<Contact> {
+  constructor() {
+    super(
+      {
+        filename: getAppHomeFolder("/", ADDRESS_BOOK_STORAGE_NAME),
+        autoload: true,
+        timestampData: true,
+      },
+      [
+        {
+          fieldName: "address",
+          unique: true,
+        },
+      ],
+    );
+
+    this.migrations();
+  }
+
+  private migrations() {
+    this.storage.update(
+      { order: { $exists: false } },
+      { $set: { order: 0 } },
+      { multi: true, returnUpdatedDocs: true },
+    );
+
+    let cnt = 1;
+
+    this.storage.find({ order: 0 }).exec((err, docs) => {
+      docs.forEach((doc) => {
+        this.storage.update(doc, { $set: { order: cnt } });
+        cnt++;
+      });
+    });
+  }
+
+  getNextNumber(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      this.storage
+        .find({})
+        .sort({ order: -1 })
+        .limit(1)
+        .exec((err, docs) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve((docs.at(0)?.order || 0) + 1);
+          }
+        });
+    });
+  }
+
+  list(searchTerm: string, sort: SortType): Promise<Contact[]> {
+    return new Promise((resolve, reject) => {
+      this.storage
+        .find({
+          $or: [
+            { name: new RegExp(`${searchTerm}.*`, "i") },
+            { address: new RegExp(`${searchTerm}.*`, "i") },
+          ],
+        })
+        .sort({ createdAt: sort === SortType.DESC ? -1 : 1 })
+        .exec((err, contacts) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(contacts);
+          }
+        });
+    });
+  }
+
+  async add(entity: Omit<Contact, "_id" | "order">): Promise<Contact> {
+    const record = await this.find({ address: entity.address });
+    if (record) {
+      throw new Error(
+        `Account with public address '${entity.address}' already exists`,
+      );
+    }
+
+    const order = await this.getNextNumber();
+    const contact = await super.add({ ...entity, order: order });
+
+    return contact;
+  }
+}
+
+export default AddressBookStorage;

--- a/main/api/address-book/v1/Contact.ts
+++ b/main/api/address-book/v1/Contact.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+import Entity from "./Entity";
+
+export const ContactSchema = z.object({
+  name: z.string(),
+  address: z.string(),
+});
+
+interface Contact extends Entity {
+  name: string;
+  address: string;
+  order?: number;
+}
+
+export default Contact;

--- a/main/api/address-book/v1/Entity.ts
+++ b/main/api/address-book/v1/Entity.ts
@@ -1,0 +1,5 @@
+interface Entity {
+  _id: string;
+}
+
+export default Entity;

--- a/main/api/address-book/v1/IStorage.ts
+++ b/main/api/address-book/v1/IStorage.ts
@@ -1,0 +1,16 @@
+import Entity from "./Entity";
+import SortType from "./SortType";
+
+interface IStorage<T extends Entity> {
+  add: (entity: Partial<Omit<T, "_id">>) => Promise<T>;
+  delete: (identity: string) => Promise<void>;
+  find: (entity: Partial<Omit<T, "_id">>) => Promise<T | null>;
+  get: (identity: string) => Promise<T | null>;
+  list: (searchTerm: string, sort: SortType) => Promise<T[]>;
+  update: (
+    identity: string,
+    fieldsToUpdate: Partial<Omit<T, "_id">>,
+  ) => Promise<T>;
+}
+
+export default IStorage;

--- a/main/api/address-book/v1/SortType.ts
+++ b/main/api/address-book/v1/SortType.ts
@@ -1,0 +1,6 @@
+enum SortType {
+  ASC = "asc",
+  DESC = "desc",
+}
+
+export default SortType;

--- a/main/api/index.ts
+++ b/main/api/index.ts
@@ -7,6 +7,8 @@ import { z } from "zod";
 
 import { handleGetAccount } from "./accounts/handleGetAccount";
 import { handleGetAccounts } from "./accounts/handleGetAccounts";
+import { ContactSchema } from "./address-book/v1/Contact";
+import SortType from "./address-book/v1/SortType";
 import { manager } from "./manager";
 import { handleGetTransaction } from "./transactions/handleGetTransaction";
 import { handleGetTransactions } from "./transactions/handleGetTransactions";
@@ -100,6 +102,15 @@ export const router = t.router({
   downloadSnapshot: t.procedure.mutation(async () => {
     const ironfish = await manager.getIronfish();
     ironfish.downloadSnapshot();
+  }),
+  v1GetContacts: t.procedure.input(z.string()).query((opts) => {
+    return manager.v1AddressBook.list(opts.input, SortType.ASC);
+  }),
+  v1AddContact: t.procedure.input(ContactSchema).mutation(async (opts) => {
+    return manager.v1AddressBook.add(opts.input);
+  }),
+  v1DeleteContact: t.procedure.input(z.string()).mutation(async (opts) => {
+    return manager.v1AddressBook.delete(opts.input);
   }),
   startNode: t.procedure.mutation(async () => {
     const ironfish = await manager.getIronfish();

--- a/main/api/manager.ts
+++ b/main/api/manager.ts
@@ -1,3 +1,4 @@
+import { AddressBookStorage } from "./address-book/v1/AddressBookStorage";
 import { Ironfish } from "./ironfish";
 import { UserSettingsStore, loadUserSettings } from "./userSettings";
 
@@ -10,6 +11,7 @@ export class Manager {
   private _userSettings: UserSettingsStore | null = null;
   private _ironfish: Ironfish | null = null;
   private _initialState: InitialState | null = null;
+  public v1AddressBook: AddressBookStorage = new AddressBookStorage();
 
   async getUserSettings(): Promise<UserSettingsStore> {
     if (this._userSettings) return this._userSettings;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "electron-log": "^4.4.8",
     "electron-serve": "^1.1.0",
     "electron-store": "^8.1.0",
+    "nedb": "^1.8.0",
     "tar": "^6.2.0",
     "uuid": "^9.0.1"
   },
@@ -37,6 +38,7 @@
     "@trpc/react-query": "^10.38.5",
     "@trpc/server": "^10.38.5",
     "@types/lodash-es": "^4.17.9",
+    "@types/nedb": "^1.8.14",
     "@types/node": "^18.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2635,6 +2635,13 @@
   resolved "https://registry.npmjs.org/@types/ms/-/ms-0.7.32.tgz"
   integrity sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g==
 
+"@types/nedb@^1.8.14":
+  version "1.8.14"
+  resolved "https://registry.yarnpkg.com/@types/nedb/-/nedb-1.8.14.tgz#bc9132c3cd743f8f4d72dd70ffb59258ddd4bc35"
+  integrity sha512-LrMiCgvAAxoIBgLD0xaP23AbI6YSJ49VpD7W/YHAE9+vfo7W7KzfENxGQC83vHJokJ+tJiW0bwkZWE1l5ZVYDg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "20.8.2"
   resolved "https://registry.npmjs.org/@types/node/-/node-20.8.2.tgz"
@@ -3275,6 +3282,11 @@ async-exit-hook@^2.0.1:
   resolved "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz"
   integrity sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==
 
+async@0.2.10:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
+  integrity sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==
+
 async@^3.2.3:
   version "3.2.4"
   resolved "https://registry.npmjs.org/async/-/async-3.2.4.tgz"
@@ -3381,6 +3393,13 @@ bech32@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz"
   integrity sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==
+
+binary-search-tree@0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/binary-search-tree/-/binary-search-tree-0.2.5.tgz#7dbb3b210fdca082450dad2334c304af39bdc784"
+  integrity sha512-CvNVKS6iXagL1uGwLagSXz1hzSMezxOuGnFi5FHGKqaTO3nPPWrAbyALUzK640j+xOTVm7lzD9YP8W1f/gvUdw==
+  dependencies:
+    underscore "~1.4.4"
 
 bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
@@ -5296,6 +5315,11 @@ immediate@^3.2.3:
   resolved "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz"
   integrity sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
+
 import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz"
@@ -5825,6 +5849,13 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  integrity sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==
+  dependencies:
+    immediate "~3.0.5"
+
 lilconfig@2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz"
@@ -5867,6 +5898,13 @@ loader-runner@^4.2.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz"
   integrity sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==
+
+localforage@^1.3.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.10.0.tgz#5c465dc5f62b2807c3a84c0c6a1b1b3212781dd4"
+  integrity sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^3.0.0:
   version "3.0.0"
@@ -6228,6 +6266,13 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mkdirp@~0.5.1:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
+  dependencies:
+    minimist "^1.2.6"
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
@@ -6257,6 +6302,17 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+nedb@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/nedb/-/nedb-1.8.0.tgz#0e3502cd82c004d5355a43c9e55577bd7bd91d88"
+  integrity sha512-ip7BJdyb5m+86ZbSb4y10FCCW9g35+U8bDRrZlAfCI6m4dKwEsQ5M52grcDcVK4Vm/vnPlDLywkyo3GliEkb5A==
+  dependencies:
+    async "0.2.10"
+    binary-search-tree "0.2.5"
+    localforage "^1.3.0"
+    mkdirp "~0.5.1"
+    underscore "~1.4.4"
 
 negotiator@^0.6.2, negotiator@^0.6.3:
   version "0.6.3"
@@ -7808,6 +7864,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+underscore@~1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
+  integrity sha512-ZqGrAgaqqZM7LGRzNjLnw5elevWb5M8LEoDMadxIW3OWbcv72wMMgKdwOKpd5Fqxe8choLD8HN3iSj3TUh/giQ==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Migrate over address book storage from V1 node app. The plan is to rewrite address book without using nedb but either way we will need to do a database migration for existing users coming from Node App V1
