### PR TITLE
Add graceful shutdown to app

### DIFF
--- a/main/api/ironfish/Ironfish.ts
+++ b/main/api/ironfish/Ironfish.ts
@@ -59,7 +59,7 @@ export class Ironfish {
     }
     this._initialized = true;
 
-    console.log("Initializing IronFish SDK...");
+    log.log("Initializing Iron Fish SDK...");
 
     const sdk = await IronfishSdk.init({
       dataDir: this._dataDir,
@@ -83,7 +83,7 @@ export class Ironfish {
       await this.snapshotManager.result();
     }
 
-    console.log("Starting Iron Fish Node...");
+    log.log("Starting Iron Fish Node...");
 
     const sdk = await this.sdk();
     const node = await sdk.node({
@@ -118,7 +118,7 @@ export class Ironfish {
 
   async stop() {
     if (this._fullNode) {
-      console.log("Stopping Iron Fish Node...");
+      log.log("Stopping Iron Fish Node...");
       await this._fullNode.shutdown();
       await this._fullNode.closeDB();
       this._fullNode = null;

--- a/main/api/ironfish/Ironfish.ts
+++ b/main/api/ironfish/Ironfish.ts
@@ -32,6 +32,10 @@ export class Ironfish {
     this._dataDir = dataDir;
   }
 
+  isStarted(): boolean {
+    return this._started;
+  }
+
   rpcClient(): Promise<RpcClient> {
     return this.rpcClientPromise.promise;
   }
@@ -79,7 +83,7 @@ export class Ironfish {
       await this.snapshotManager.result();
     }
 
-    console.log("Starting IronFish Node...");
+    console.log("Starting Iron Fish Node...");
 
     const sdk = await this.sdk();
     const node = await sdk.node({
@@ -114,6 +118,7 @@ export class Ironfish {
 
   async stop() {
     if (this._fullNode) {
+      console.log("Stopping Iron Fish Node...");
       await this._fullNode.shutdown();
       await this._fullNode.closeDB();
       this._fullNode = null;

--- a/main/background.ts
+++ b/main/background.ts
@@ -45,3 +45,13 @@ if (isProd) {
 app.on("window-all-closed", () => {
   app.quit();
 });
+
+app.on("will-quit", (e) => {
+  // Attempt to shut down the node gracefully before exiting the app
+  if (ironfish.isStarted()) {
+    e.preventDefault();
+    ironfish.stop().then(() => {
+      app.quit();
+    });
+  }
+});


### PR DESCRIPTION
Attempts to shut down the node gracefully when the Electron app closes. I haven't had any problems with this yet, but I imagine it can help avoid database corruption and let p2p peers know that the node is going away, which is always nice.