### PR TITLE
Only log info and above logs to file

### DIFF
--- a/main/api/snapshot/snapshotManager.ts
+++ b/main/api/snapshot/snapshotManager.ts
@@ -65,7 +65,7 @@ export class SnapshotManager {
     downloadSpeed.start();
 
     await Downloader.download((prev, curr) => {
-      log.log(`Download progress: ${curr}/${manifest.file_size}`);
+      log.debug(`Download progress: ${curr}/${manifest.file_size}`);
       downloadSpeed.add(curr - prev);
 
       this.onProgress.emit({
@@ -95,7 +95,7 @@ export class SnapshotManager {
           prevExtracted: number,
           currExtracted: number,
         ) => {
-          log.log(`Unzip progress: ${currExtracted}/${totalEntries}`);
+          log.debug(`Unzip progress: ${currExtracted}/${totalEntries}`);
           unzipSpeed.add(currExtracted - prevExtracted);
 
           this.onProgress.emit({

--- a/main/background.ts
+++ b/main/background.ts
@@ -1,4 +1,5 @@
 import { app } from "electron";
+import log from "electron-log";
 import serve from "electron-serve";
 import { createIPCHandler } from "electron-trpc/main";
 
@@ -8,6 +9,8 @@ import { mainWindow } from "./main-window";
 import { updater } from "./updater";
 
 const isProd: boolean = process.env.NODE_ENV === "production";
+
+log.transports.file.level = "info";
 
 const ironfish = await manager.getIronfish();
 ironfish.init();


### PR DESCRIPTION
The snapshot logs are a bit spammy to output to the file logs, so bumped them down to debug level and set the file transport to only log info logs.