### PR TITLE
Set BrowserWindow webPreferences to default values

### DIFF
--- a/main/main-window.ts
+++ b/main/main-window.ts
@@ -116,7 +116,6 @@ class MainWindow {
       titleBarStyle: "hidden",
       webPreferences: {
         preload: path.join(__dirname, "preload.js"),
-        sandbox: false,
       },
     });
 

--- a/main/main-window.ts
+++ b/main/main-window.ts
@@ -116,8 +116,6 @@ class MainWindow {
       titleBarStyle: "hidden",
       webPreferences: {
         preload: path.join(__dirname, "preload.js"),
-        nodeIntegration: false,
-        contextIsolation: true,
         sandbox: false,
       },
     });


### PR DESCRIPTION
We can enable the sandbox in the BrowserWindow now, since we're not using anything from online or from Node in the renderer process.

- Remove nodeIntegration and contextIsolation values that are set to default
- Enable sandbox (by setting it to the default value)
