### PR TITLE
Fix closing window killing process on macOS

### DIFF
--- a/main/main-window.ts
+++ b/main/main-window.ts
@@ -120,6 +120,13 @@ class MainWindow {
       },
     });
 
+    this.window.on("closed", () => {
+      this.window = null;
+      const [promise, resolve] = PromiseUtils.split<BrowserWindow>();
+      this.windowPromise = promise;
+      this.windowResolve = resolve;
+    });
+
     this.windowResolve(this.window);
     return this.window;
   }


### PR DESCRIPTION
Fixes a UX issue where closing the window on macOS would kill the process -- usually that's not typical macOS app behavior, as demonstrated in the Electron quick start docs: https://www.electronjs.org/docs/latest

Also set the app to wait for the ready-to-show event before displaying the window to avoid a flash of unstyled window, and fixed an issue where the app wasn't working in production builds on my machine due to waiting too long to start electron-serve.
