### PR TITLE
Upgrade Electron to 27.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "consola": "^2.15.0",
         "date-fns": "^2.30.0",
         "date-fns-tz": "^2.0.0",
-        "electron": "^26.2.2",
+        "electron": "^27.1.2",
         "electron-builder": "^24.6.4",
         "electron-log": "5.0.0",
         "electron-store": "^8.1.0",
@@ -8073,9 +8073,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-26.5.0.tgz",
-      "integrity": "sha512-j65/SMEqf+sKBUmAwYU0E5d/OKPmhRVyMntVulHKTNEazxF2TuRr/+GoEVxBq4l9jfLEXhheVOuOW0J5Tme1kA==",
+      "version": "27.1.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-27.1.2.tgz",
+      "integrity": "sha512-Dy6BUuGLiIJv+zfsXwr78TV2TNppi24rXF4PIIS+OjDblEKdkI9r1iM8JUd3/x3sbGUy5mdLMSPhvmu//IhkgA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "electron-store": "^8.1.0",
     "electron-trpc": "^0.5.2",
     "electron-updater": "6.1.4",
-    "electron": "^26.2.2",
+    "electron": "^27.1.2",
     "eslint-config-next": "^13.5.4",
     "eslint-config-prettier": "^9.0.0",
     "eslint-import-resolver-typescript": "^3.6.1",


### PR DESCRIPTION
No conflicts with our app, so that's great! The bundled version of Node.js is still on version 18 though.
