### PR TITLE
Disable Windows code signing on local builds

### DIFF
--- a/build/sign-windows.js
+++ b/build/sign-windows.js
@@ -2,6 +2,17 @@ const { exec } = require("child_process");
 
 exports.default = async function (configuration) {
   return new Promise((resolve, reject) => {
+    if (
+      process.env.CI === undefined ||
+      process.env.CI.toLowerCase().trim() === "false"
+    ) {
+      console.warn(
+        "CI environment variable is unset or false, skipping code signing",
+      );
+      resolve();
+      return;
+    }
+
     const cmd = `AzureSignTool sign -kvu "${process.env.AZURE_KEY_VAULT_URI}" -kvi "${process.env.AZURE_CLIENT_ID}" -kvt "${process.env.AZURE_TENANT_ID}" -kvs "${process.env.AZURE_CLIENT_SECRET}" -kvc "${process.env.AZURE_CERT_NAME}" -tr http://timestamp.digicert.com -v "${configuration.path}"`;
 
     exec(cmd, (error, stdout, stderr) => {


### PR DESCRIPTION
Windows local builds error out at the code signing phase unless you (unlikely) have AzureSignTool and all the proper environment variables set. The easiest way I could think of to make sure we don't accidentally ship builds without code signing while still allowing local builds is to skip code signing on Windows if the CI environment variable is set. GitHub Actions sets it to true by default.