### PR TITLE
Add Waiting for Peers status to status indicator

### DIFF
--- a/renderer/components/StatusIndicator/StatusIndicator.tsx
+++ b/renderer/components/StatusIndicator/StatusIndicator.tsx
@@ -32,6 +32,12 @@ function useStatus() {
           : "Syncing blocks",
       };
     }
+    if (!data.blockchain.synced) {
+      return {
+        status: "SYNCING",
+        label: "Waiting for peers to sync from",
+      };
+    }
     if (data.accounts.head.hash !== data.blockchain.head.hash) {
       return {
         status: "SCANNING",


### PR DESCRIPTION
Adds a state to the status indicator that checks data.blockchain.synced. Right now, when the syncer stops syncing to re-test connections to different peers, the status indicator shows "Synced", but the CLI status command shows NOT SYNCED for the chain. This value comes from data.blockchain.synced, so hooking it up should more accurately show the current chain status.

Fixes IFL-1870