### PR TITLE
Update app metadata

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,10 @@
-appId: com.example.iron-fish-node-app
+appId: network.iflabs.ironfish-node-app
 productName: Iron Fish Node App
 copyright: Copyright © 2023 IF Labs
+# The app name in the Mac application menu uses the value from the
+# name field in package.json unless this is set.
+extraMetadata:
+  name: Iron Fish Node App
 directories:
   output: dist
   buildResources: resources

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "my-nextron-app",
+  "name": "ironfish-node-app",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "my-nextron-app",
+      "name": "ironfish-node-app",
       "version": "1.0.0",
       "hasInstallScript": true,
       "license": "MPL-2.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "private": true,
-  "name": "my-nextron-app",
+  "name": "ironfish-node-app",
   "description": "Iron Fish Node App",
-  "version": "1.0.0",
-  "author": "if-labs",
+  "version": "2.0.0",
+  "author": "IF Labs <engineering@iflabs.network> (https://iflabs.network)",
   "main": "app/background.js",
   "scripts": {
     "dev": "nextron",


### PR DESCRIPTION
Updates metadata to make sure the app displays "Iron Fish Node App" everywhere.

I also bumped the version to 2.0, so it won't end up conflicting with the previous node app.

Fixes IFL-1114
