### PR TITLE
Default react-query networkMode to always

### DIFF
--- a/renderer/providers/TRPCProvider.tsx
+++ b/renderer/providers/TRPCProvider.tsx
@@ -25,6 +25,10 @@ export function TRPCProvider({ children }: { children: ReactNode }) {
         defaultOptions: {
           queries: {
             refetchInterval: 1000 * 30,
+            networkMode: "always",
+          },
+          mutations: {
+            networkMode: "always",
           },
         },
       }),


### PR DESCRIPTION
By default, react-query queries are held in a paused state if the network is offline. Since we're just using react-query to talk to the Electron backend over IPC, I think we generally want these to go through unless specifically accessing the network.
