### PR TITLE
Retry with exponential backoff if snapshot download fails

### DIFF
--- a/main/api/snapshot/index.ts
+++ b/main/api/snapshot/index.ts
@@ -1,36 +1,39 @@
 import { ErrorUtils } from "@ironfish/sdk";
 import { observable } from "@trpc/server/observable";
+import { z } from "zod";
 
 import { SnapshotUpdate } from "../../../shared/types";
 import { manager } from "../manager";
 import { t } from "../trpc";
 
 export const snapshotRouter = t.router({
-  snapshotProgress: t.procedure.subscription(async () => {
-    const ironfish = await manager.getIronfish();
+  snapshotProgress: t.procedure
+    .input(z.object({ id: z.number() }))
+    .subscription(async () => {
+      const ironfish = await manager.getIronfish();
 
-    return observable<SnapshotUpdate>((emit) => {
-      const onProgress = (update: SnapshotUpdate) => {
-        emit.next(update);
-      };
+      return observable<SnapshotUpdate>((emit) => {
+        const onProgress = (update: SnapshotUpdate) => {
+          emit.next(update);
+        };
 
-      ironfish.snapshotManager.onProgress.on(onProgress);
+        ironfish.snapshotManager.onProgress.on(onProgress);
 
-      ironfish.snapshotManager
-        .result()
-        .then(() => {
-          emit.next({ step: "complete" });
-        })
-        .catch((err) => {
-          const error = ErrorUtils.renderError(err);
-          emit.error(error);
-        });
+        ironfish.snapshotManager
+          .result()
+          .then(() => {
+            emit.next({ step: "complete" });
+          })
+          .catch((err) => {
+            const error = ErrorUtils.renderError(err);
+            emit.error(error);
+          });
 
-      return () => {
-        ironfish.snapshotManager.onProgress.off(onProgress);
-      };
-    });
-  }),
+        return () => {
+          ironfish.snapshotManager.onProgress.off(onProgress);
+        };
+      });
+    }),
   downloadSnapshot: t.procedure.mutation(async () => {
     const ironfish = await manager.getIronfish();
     ironfish.downloadSnapshot();

--- a/main/api/snapshot/snapshotManager.ts
+++ b/main/api/snapshot/snapshotManager.ts
@@ -28,6 +28,9 @@ export class SnapshotManager {
       this.snapshotPromise.resolve();
     } catch (e) {
       this.snapshotPromise.reject(e);
+    } finally {
+      this.started = false;
+      this.snapshotPromise = splitPromise();
     }
   }
 
@@ -36,6 +39,9 @@ export class SnapshotManager {
   }
 
   async _run(sdk: IronfishSdk, node: FullNode): Promise<void> {
+    if (!node.chain.blockchainDb.db.isOpen) {
+      await node.openDB();
+    }
     const nodeChainDBVersion = await node.chain.blockchainDb.getVersion();
     await node.closeDB();
 


### PR DESCRIPTION
Adds logic for retrying the snapshot download with exponential backoff if it errors out while in the download process.

Ideally I think this should live on the backend in the shared Snapshot code, and the frontend should just be responsible for starting/stopping the snapshot download service. 

Fixes IFL-1832
