### PR TITLE
Start crash reporter on app start

### DIFF
--- a/main/background.ts
+++ b/main/background.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, app, nativeTheme } from "electron";
+import { BrowserWindow, app, nativeTheme, crashReporter } from "electron";
 import log from "electron-log";
 import serve from "electron-serve";
 import { createIPCHandler } from "electron-trpc/main";
@@ -17,6 +17,8 @@ if (isProd) {
 } else {
   app.setPath("userData", `${app.getPath("userData")} (development)`);
 }
+
+crashReporter.start({ uploadToServer: false });
 
 const ironfish = await manager.getIronfish();
 ironfish.init();


### PR DESCRIPTION
We used to use this on the old app, but haven't turned it on in the new one. It has occasionally been useful for determining that one of the native modules is crashing the process.
