### PR TITLE
Virtualize list of notes on Account Overview page

### DIFF
--- a/main/api/transactions/handleGetTransactions.ts
+++ b/main/api/transactions/handleGetTransactions.ts
@@ -16,13 +16,12 @@ export async function handleGetTransactions({
   const ironfish = await manager.getIronfish();
   const rpcClient = await ironfish.rpcClient();
 
-  const transactionsStream =
-    await rpcClient.wallet.getAccountTransactionsStream({
-      offset: cursor,
-      limit: limit,
-      account: accountName,
-      notes: true,
-    });
+  const transactionsStream = rpcClient.wallet.getAccountTransactionsStream({
+    offset: cursor,
+    limit: limit,
+    account: accountName,
+    notes: true,
+  });
 
   const transactions = await resolveContentStream(
     transactionsStream.contentStream(),

--- a/main/api/transactions/index.ts
+++ b/main/api/transactions/index.ts
@@ -31,6 +31,8 @@ export const transactionRouter = t.router({
     .input(
       z.object({
         accountName: z.string(),
+        cursor: z.number().optional(),
+        limit: z.number().min(1).max(100).optional(),
       }),
     )
     .query(async (opts) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "react-icons": "^4.11.0",
         "react-intl": "^6.5.5",
         "react-markdown": "9.0.1",
+        "react-virtuoso": "^4.6.2",
         "tar": "^6.2.0",
         "type-fest": "^4.6.0",
         "typescript": "^5.2.2",
@@ -14077,6 +14078,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-virtuoso": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.6.2.tgz",
+      "integrity": "sha512-vvlqvzPif+MvBrJ09+hJJrVY0xJK9yran+A+/1iwY78k0YCVKsyoNPqoLxOxzYPggspNBNXqUXEcvckN29OxyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18",
+        "react-dom": ">=16 || >=17 || >= 18"
       }
     },
     "node_modules/read-config-file": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "react-icons": "^4.11.0",
     "react-intl": "^6.5.5",
     "react-markdown": "9.0.1",
+    "react-virtuoso": "^4.6.2",
     "tar": "^6.2.0",
     "type-fest": "^4.6.0",
     "typescript": "^5.2.2",

--- a/renderer/components/NotesList/NotesList.tsx
+++ b/renderer/components/NotesList/NotesList.tsx
@@ -1,15 +1,25 @@
-import { Box, Heading } from "@chakra-ui/react";
+import { Box, Heading, Skeleton } from "@chakra-ui/react";
+import { useContext } from "react";
 import { defineMessages, useIntl } from "react-intl";
+import { Virtuoso } from "react-virtuoso";
 
 import {
   TransactionRow,
   TransactionsHeadings,
 } from "@/components/TransactionRow/TransactionRow";
+import { ScrollElementContext } from "@/layouts/MainLayout";
 
 import { TransactionNote } from "../../../shared/types";
 import { EmptyStateMessage } from "../EmptyStateMessage/EmptyStateMessage";
 
 const messages = defineMessages({
+  errorStateHeading: {
+    defaultMessage: "Unable to load your transactions",
+  },
+  errorStateDescription: {
+    defaultMessage:
+      "An error occurred while loading your transactions. If this happens several times, please let us know on Discord.",
+  },
   emptyStateHeading: {
     defaultMessage: "You don't have any transactions",
   },
@@ -23,16 +33,31 @@ type Props = {
   notes: TransactionNote[];
   heading?: string;
   linkToTransaction?: boolean;
+  isError?: boolean;
+  isLoading?: boolean;
 };
 
 export function NotesList({
   notes,
   heading = "Transaction Notes",
   linkToTransaction = false,
+  isError,
+  isLoading,
 }: Props) {
   const { formatMessage } = useIntl();
+  const customScrollElement = useContext(ScrollElementContext);
 
-  if (notes.length === 0) {
+  if (isError) {
+    return (
+      <EmptyStateMessage
+        py={8}
+        heading={formatMessage(messages.errorStateHeading)}
+        description={formatMessage(messages.errorStateDescription)}
+      />
+    );
+  }
+
+  if (!isLoading && notes.length === 0) {
     return (
       <EmptyStateMessage
         py={8}
@@ -41,29 +66,37 @@ export function NotesList({
       />
     );
   }
+
   return (
     <Box>
       <Heading as="h2" fontSize="2xl" mb={8}>
         {heading}
       </Heading>
       <TransactionsHeadings />
-      {notes.map((note) => {
-        return (
-          <TransactionRow
-            key={note.noteHash}
-            accountName={note.accountName}
-            assetName={note.assetName}
-            value={note.value}
-            timestamp={note.timestamp}
-            from={note.from}
-            to={note.to}
-            transactionHash={note.transactionHash}
-            type={note.type}
-            memo={note.memo}
-            linkToTransaction={linkToTransaction}
-          />
-        );
-      })}
+      {isLoading && <Skeleton height="600px" />}
+      {!isLoading && customScrollElement && (
+        <Virtuoso
+          customScrollParent={customScrollElement}
+          data={notes}
+          itemContent={(_, note) => {
+            return (
+              <TransactionRow
+                key={note.noteHash}
+                accountName={note.accountName}
+                assetName={note.assetName}
+                value={note.value}
+                timestamp={note.timestamp}
+                from={note.from}
+                to={note.to}
+                transactionHash={note.transactionHash}
+                type={note.type}
+                memo={note.memo}
+                linkToTransaction={linkToTransaction}
+              />
+            );
+          }}
+        />
+      )}
     </Box>
   );
 }

--- a/renderer/components/NotesList/NotesList.tsx
+++ b/renderer/components/NotesList/NotesList.tsx
@@ -1,5 +1,4 @@
 import { Box, Heading, Skeleton } from "@chakra-ui/react";
-import { useContext } from "react";
 import { defineMessages, useIntl } from "react-intl";
 import { Virtuoso } from "react-virtuoso";
 
@@ -7,7 +6,7 @@ import {
   TransactionRow,
   TransactionsHeadings,
 } from "@/components/TransactionRow/TransactionRow";
-import { ScrollElementContext } from "@/layouts/MainLayout";
+import { useScrollElementContext } from "@/layouts/MainLayout";
 
 import { TransactionNote } from "../../../shared/types";
 import { EmptyStateMessage } from "../EmptyStateMessage/EmptyStateMessage";
@@ -45,7 +44,7 @@ export function NotesList({
   isLoading,
 }: Props) {
   const { formatMessage } = useIntl();
-  const customScrollElement = useContext(ScrollElementContext);
+  const customScrollElement = useScrollElementContext();
 
   if (isError) {
     return (

--- a/renderer/components/TransactionRow/TransactionRow.tsx
+++ b/renderer/components/TransactionRow/TransactionRow.tsx
@@ -1,5 +1,5 @@
 import { ChevronRightIcon } from "@chakra-ui/icons";
-import { Grid, GridItem, HStack, Text } from "@chakra-ui/react";
+import { Box, Grid, GridItem, HStack, Text } from "@chakra-ui/react";
 import type { TransactionType } from "@ironfish/sdk";
 
 import { MaybeLink } from "@/ui/ChakraLink/ChakraLink";
@@ -74,62 +74,65 @@ export function TransactionRow({
       }
       w="100%"
     >
-      <ShadowCard
-        hoverable={linkToTransaction}
-        height="86px"
-        contentContainerProps={{
-          display: "flex",
-          alignItems: "center",
-          p: 0,
-        }}
-        mb={4}
-      >
-        <Grid
-          templateColumns={{
-            base: `repeat(5, 1fr)`,
-            md: linkToTransaction ? `repeat(5, 1fr) 55px` : `repeat(5, 1fr)`,
+      <Box py={2}>
+        <ShadowCard
+          hoverable={linkToTransaction}
+          height="86px"
+          contentContainerProps={{
+            display: "flex",
+            alignItems: "center",
+            p: 0,
           }}
-          opacity="0.8"
-          w="100%"
-          gap={4}
         >
-          <GridItem display="flex" alignItems="center" pl={8}>
-            <HStack gap={4}>
-              {type === "send" ? <SentIcon /> : <ReceivedIcon />}
-              <Text as="span">{type === "send" ? "Sent" : "Received"}</Text>
-            </HStack>
-          </GridItem>
-          <GridItem display="flex" alignItems="center">
-            <Text as="span">
-              {formatOre(value)} {hexToUTF16String(assetName)}
-            </Text>
-          </GridItem>
-          <GridItem display="flex" alignItems="center">
-            <Text as="span">{truncateString(type === "send" ? to : from)}</Text>
-          </GridItem>
-          <GridItem display="flex" alignItems="center">
-            <Text as="span">{formatDate(timestamp)}</Text>
-          </GridItem>
-          <GridItem display="flex" alignItems="center">
-            <Text as="span">{memo || "—"}</Text>
-          </GridItem>
-          {linkToTransaction && (
-            <GridItem
-              alignItems="center"
-              display={{
-                base: "none",
-                md: "flex",
-              }}
-            >
-              <ChevronRightIcon
-                boxSize={5}
-                color={COLORS.GRAY_MEDIUM}
-                _dark={{ color: COLORS.DARK_MODE.GRAY_LIGHT }}
-              />
+          <Grid
+            templateColumns={{
+              base: `repeat(5, 1fr)`,
+              md: linkToTransaction ? `repeat(5, 1fr) 55px` : `repeat(5, 1fr)`,
+            }}
+            opacity="0.8"
+            w="100%"
+            gap={4}
+          >
+            <GridItem display="flex" alignItems="center" pl={8}>
+              <HStack gap={4}>
+                {type === "send" ? <SentIcon /> : <ReceivedIcon />}
+                <Text as="span">{type === "send" ? "Sent" : "Received"}</Text>
+              </HStack>
             </GridItem>
-          )}
-        </Grid>
-      </ShadowCard>
+            <GridItem display="flex" alignItems="center">
+              <Text as="span">
+                {formatOre(value)} {hexToUTF16String(assetName)}
+              </Text>
+            </GridItem>
+            <GridItem display="flex" alignItems="center">
+              <Text as="span">
+                {truncateString(type === "send" ? to : from)}
+              </Text>
+            </GridItem>
+            <GridItem display="flex" alignItems="center">
+              <Text as="span">{formatDate(timestamp)}</Text>
+            </GridItem>
+            <GridItem display="flex" alignItems="center">
+              <Text as="span">{memo || "—"}</Text>
+            </GridItem>
+            {linkToTransaction && (
+              <GridItem
+                alignItems="center"
+                display={{
+                  base: "none",
+                  md: "flex",
+                }}
+              >
+                <ChevronRightIcon
+                  boxSize={5}
+                  color={COLORS.GRAY_MEDIUM}
+                  _dark={{ color: COLORS.DARK_MODE.GRAY_LIGHT }}
+                />
+              </GridItem>
+            )}
+          </Grid>
+        </ShadowCard>
+      </Box>
     </MaybeLink>
   );
 }

--- a/renderer/layouts/MainLayout.tsx
+++ b/renderer/layouts/MainLayout.tsx
@@ -8,7 +8,7 @@ import {
   Flex,
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
-import { createContext, ReactNode, useState } from "react";
+import { createContext, ReactNode, useContext, useState } from "react";
 
 import { BackButton } from "@/components/BackButton/BackButton";
 import { StatusIndicator } from "@/components/StatusIndicator/StatusIndicator";
@@ -143,7 +143,11 @@ type Props = {
   };
 };
 
-export const ScrollElementContext = createContext<HTMLDivElement | null>(null);
+const ScrollElementContext = createContext<HTMLDivElement | null>(null);
+
+export function useScrollElementContext() {
+  return useContext(ScrollElementContext);
+}
 
 export default function MainLayout({ children, backLinkProps }: Props) {
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(

--- a/renderer/layouts/MainLayout.tsx
+++ b/renderer/layouts/MainLayout.tsx
@@ -8,7 +8,7 @@ import {
   Flex,
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
-import { ReactNode } from "react";
+import { createContext, ReactNode, useState } from "react";
 
 import { BackButton } from "@/components/BackButton/BackButton";
 import { StatusIndicator } from "@/components/StatusIndicator/StatusIndicator";
@@ -143,7 +143,13 @@ type Props = {
   };
 };
 
+export const ScrollElementContext = createContext<HTMLDivElement | null>(null);
+
 export default function MainLayout({ children, backLinkProps }: Props) {
+  const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(
+    null,
+  );
+
   return (
     <WithDraggableArea
       bg="white"
@@ -166,25 +172,34 @@ export default function MainLayout({ children, backLinkProps }: Props) {
         >
           <Sidebar />
         </GridItem>
-        <GridItem px={6} pt={10} pb={8} h="100%" overflow="auto">
-          <Box
-            mx="auto"
-            maxWidth={{
-              base: "100%",
-              sm: "597px",
-              lg: "825px",
-              xl: "1048px",
-              "2xl": "1280px",
-            }}
-          >
-            {backLinkProps && (
-              <BackButton
-                href={backLinkProps.href}
-                label={backLinkProps.label}
-              />
-            )}
-            {children}
-          </Box>
+        <GridItem
+          px={6}
+          pt={10}
+          pb={8}
+          h="100%"
+          overflow="auto"
+          ref={(r) => setScrollElement(r)}
+        >
+          <ScrollElementContext.Provider value={scrollElement}>
+            <Box
+              mx="auto"
+              maxWidth={{
+                base: "100%",
+                sm: "597px",
+                lg: "825px",
+                xl: "1048px",
+                "2xl": "1280px",
+              }}
+            >
+              {backLinkProps && (
+                <BackButton
+                  href={backLinkProps.href}
+                  label={backLinkProps.label}
+                />
+              )}
+              {children}
+            </Box>
+          </ScrollElementContext.Provider>
         </GridItem>
       </Grid>
     </WithDraggableArea>

--- a/renderer/pages/accounts/[account-name]/index.tsx
+++ b/renderer/pages/accounts/[account-name]/index.tsx
@@ -10,6 +10,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
+import { useState } from "react";
 import { defineMessages, useIntl } from "react-intl";
 
 import { AccountAssets } from "@/components/AccountAssets/AccountAssets";
@@ -23,6 +24,7 @@ import lionfishLock from "@/images/lionfish-lock.svg";
 import MainLayout from "@/layouts/MainLayout";
 import { WithExplanatorySidebar } from "@/layouts/WithExplanatorySidebar";
 import { trpcReact } from "@/providers/TRPCProvider";
+import { PillButton } from "@/ui/PillButton/PillButton";
 import { asQueryString } from "@/utils/parseRouteQuery";
 
 const messages = defineMessages({
@@ -54,15 +56,23 @@ function AccountOverviewContent({ accountName }: { accountName: string }) {
   const initialTabIndex = useInitialTabIndex();
   const { formatMessage } = useIntl();
 
+  const [cursor, setCursor] = useState(0);
+
   const { data: accountData } = trpcReact.getAccount.useQuery({
     name: accountName,
   });
 
-  const { data: transactionsData } = trpcReact.getTransactions.useQuery({
+  const {
+    data: transactionsData,
+    isLoading,
+    isError,
+  } = trpcReact.getTransactions.useQuery({
     accountName,
+    cursor,
+    limit: 10,
   });
 
-  if (!accountData || !transactionsData) {
+  if (!accountData) {
     // @todo: Error handling
     return null;
   }
@@ -100,9 +110,29 @@ function AccountOverviewContent({ accountName }: { accountName: string }) {
               <AccountAssets accountName={accountName} />
               <NotesList
                 linkToTransaction
-                notes={transactionsData}
+                isLoading={isLoading}
+                isError={isError}
+                notes={transactionsData?.transactions ?? []}
                 heading={formatMessage(messages.accountOverview)}
               />
+              <HStack flex={1} justifyContent="center">
+                <PillButton
+                  isDisabled={!transactionsData || cursor <= 0}
+                  onClick={() => {
+                    setCursor((c) => Math.max(c - 10, 0));
+                  }}
+                >
+                  Previous
+                </PillButton>
+                <PillButton
+                  isDisabled={!transactionsData?.hasNextPage}
+                  onClick={() => {
+                    setCursor((c) => c + 10);
+                  }}
+                >
+                  Next
+                </PillButton>
+              </HStack>
             </TabPanel>
             <TabPanel p={0}>
               <WithExplanatorySidebar


### PR DESCRIPTION
The airdrop account doesn't currently load on the app. This PR adds pagination and list virtualization (since we can't know how many notes will come back from fetching a certain number of transactions), which seems to help with the responsiveness.

I think in the future we might want to add back in infinite scroll from the 1.0 app, but this is at least enough to fix the airdrop account overview page.

Fixes IFL-1942
