### PR TITLE
Update back message to designs

### DIFF
--- a/renderer/intl/locales/en.json
+++ b/renderer/intl/locales/en.json
@@ -78,6 +78,9 @@
   "D3idYv": {
     "message": "Settings"
   },
+  "Fn/FTS": {
+    "message": "An error occurred while loading your transactions. If this happens several times, please let us know on Discord."
+  },
   "Gcv5yj": {
     "message": "Heap Used"
   },
@@ -152,6 +155,9 @@
   },
   "TenpoO": {
     "message": "We'd like to collect anonymous telemetry data in order to continually improve your experience. This data includes node performance, block information, and other health metrics. You can enable or disable this at any time in the node settings page."
+  },
+  "ThbkST": {
+    "message": "Unable to load your transactions"
   },
   "UTOugV": {
     "message": "Your Assets"
@@ -242,6 +248,9 @@
   },
   "yjpdGo": {
     "message": "You don't have any contacts"
+  },
+  "ytT37i": {
+    "message": "Back to all accounts"
   },
   "zAPy5e": {
     "message": "Account name — Z to A"

--- a/renderer/pages/accounts/[account-name]/index.tsx
+++ b/renderer/pages/accounts/[account-name]/index.tsx
@@ -29,6 +29,9 @@ import { PillButton } from "@/ui/PillButton/PillButton";
 import { asQueryString } from "@/utils/parseRouteQuery";
 
 const messages = defineMessages({
+  backToAccounts: {
+    defaultMessage: "Back to all accounts",
+  },
   accountOverview: {
     defaultMessage: "Account Overview",
   },
@@ -82,7 +85,7 @@ function AccountOverviewContent({ accountName }: { accountName: string }) {
     <MainLayout
       backLinkProps={{
         href: "/accounts",
-        label: formatMessage(messages.accountOverview),
+        label: formatMessage(messages.backToAccounts),
       }}
     >
       <Box>


### PR DESCRIPTION
The Account Overview page had the same text for the back button as for the page itself. The designs say "Back to all accounts", so I put that in instead.
