### PR TITLE
Show error on Transaction Error modal

### DIFF
--- a/renderer/components/SendAssetsForm/ConfirmTransactionModal/ConfirmTransactionModal.tsx
+++ b/renderer/components/SendAssetsForm/ConfirmTransactionModal/ConfirmTransactionModal.tsx
@@ -132,7 +132,7 @@ export function ConfirmTransactionModal({
                 Transaction Error
               </Heading>
               <Text fontSize="md">
-                Something went wrong. please review your transaction and try
+                Something went wrong. Please review your transaction and try
                 again.
               </Text>
 

--- a/renderer/components/SendAssetsForm/ConfirmTransactionModal/ConfirmTransactionModal.tsx
+++ b/renderer/components/SendAssetsForm/ConfirmTransactionModal/ConfirmTransactionModal.tsx
@@ -42,6 +42,7 @@ export function ConfirmTransactionModal({
     isError,
     isSuccess,
     reset,
+    error,
   } = trpcReact.sendTransaction.useMutation();
   const router = useRouter();
 
@@ -131,9 +132,14 @@ export function ConfirmTransactionModal({
                 Transaction Error
               </Heading>
               <Text fontSize="md">
-                Something went wrong, please review your transaction and try
+                Something went wrong. please review your transaction and try
                 again.
               </Text>
+
+              <Heading fontSize="lg" mt={8} mb={2}>
+                Error
+              </Heading>
+              <code>{error.message}</code>
             </>
           )}
         </ModalBody>


### PR DESCRIPTION
It'd be nice to display this somewhere besides just in the console. Ideally we shouldn't be hitting this too often though.

![image](https://github.com/iron-fish/ironfish-node-app/assets/767083/ff84dea2-5368-4371-ae65-fc25ed93ccfc)
