### PR TITLE
Add as const to the COLORS constant

### DIFF
--- a/renderer/ui/colors.ts
+++ b/renderer/ui/colors.ts
@@ -24,5 +24,5 @@ export const COLORS = {
     GREEN_DARK: "#242C18",
     YELLOW_LIGHT: "#E3DB7C",
     YELLOW_DARK: "#4B4608",
-  },
-};
+  } as const,
+} as const;


### PR DESCRIPTION
I always forget what the color values are when I'm looking at them in VS Code, so this makes them show the literal values on hover instead.

![image](https://github.com/iron-fish/ironfish-node-app/assets/767083/89382597-35de-4d9a-8871-824608e83357)

