### PR TITLE
Estimate fees using a proposed transaction instead of direct fee rates

### DIFF
--- a/main/api/transactions/handleGetEstimatedFees.ts
+++ b/main/api/transactions/handleGetEstimatedFees.ts
@@ -1,0 +1,55 @@
+import { CreateTransactionResponse, RawTransactionSerde } from "@ironfish/sdk";
+
+import { manager } from "../manager";
+
+export async function handleGetEstimatedFees({
+  accountName,
+  output,
+}: {
+  accountName: string;
+  output: {
+    amount: number;
+    memo: string;
+    publicAddress: string;
+    assetId: string;
+  };
+}) {
+  const ironfish = await manager.getIronfish();
+  const rpcClient = await ironfish.rpcClient();
+  const estimatedFees = await rpcClient.chain.estimateFeeRates();
+
+  const results: CreateTransactionResponse[] = await Promise.all(
+    [
+      estimatedFees.content.slow,
+      estimatedFees.content.average,
+      estimatedFees.content.fast,
+    ].map((feeRate) =>
+      rpcClient.wallet
+        .createTransaction({
+          account: accountName,
+          outputs: [
+            {
+              publicAddress: output.publicAddress,
+              amount: output.amount.toString(),
+              memo: output.memo,
+              assetId: output.assetId,
+            },
+          ],
+          feeRate,
+        })
+        .then((result) => result.content),
+    ),
+  );
+
+  const fees: bigint[] = results.map(
+    (result) =>
+      RawTransactionSerde.deserialize(Buffer.from(result.transaction, "hex"))
+        .fee,
+  );
+
+  return {
+    slow: parseInt(fees[0].toString()),
+    average: parseInt(fees[1].toString()),
+    fast: parseInt(fees[2].toString()),
+  };
+}

--- a/main/api/transactions/index.ts
+++ b/main/api/transactions/index.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { handleGetEstimatedFees } from "./handleGetEstimatedFees";
 import { handleGetTransaction } from "./handleGetTransaction";
 import { handleGetTransactions } from "./handleGetTransactions";
 import { handleGetTransactionsForContact } from "./handleGetTransactionsForContact";
@@ -7,16 +8,24 @@ import {
   handleSendTransaction,
   handleSendTransactionInput,
 } from "./handleSendTransaction";
-import { manager } from "../manager";
 import { t } from "../trpc";
 
 export const transactionRouter = t.router({
-  getEstimatedFees: t.procedure.query(async () => {
-    const ironfish = await manager.getIronfish();
-    const rpcClient = await ironfish.rpcClient();
-    const estimatedFees = await rpcClient.chain.estimateFeeRates();
-    return estimatedFees.content;
-  }),
+  getEstimatedFees: t.procedure
+    .input(
+      z.object({
+        accountName: z.string(),
+        output: z.object({
+          amount: z.number(),
+          memo: z.string(),
+          publicAddress: z.string(),
+          assetId: z.string(),
+        }),
+      }),
+    )
+    .query(async (opts) => {
+      return handleGetEstimatedFees(opts.input);
+    }),
   getTransaction: t.procedure
     .input(
       z.object({

--- a/renderer/components/SendAssetsForm/SendAssetsForm.tsx
+++ b/renderer/components/SendAssetsForm/SendAssetsForm.tsx
@@ -71,8 +71,6 @@ export function SendAssetsFormContent({
   const toAccountValue = watch("toAccount");
   const memoValue = watch("memo");
 
-  console.log(amountValue, parseIron(amountValue));
-
   const { data: estimatedFeesData } = trpcReact.getEstimatedFees.useQuery(
     {
       accountName: fromAccountValue,


### PR DESCRIPTION
We were treating fee rates as fees in the node app. The fee changes based on the size of the transaction, which changes based on how many spends and outputs are part of the transaction.

Updated the fees RPC to call createTransaction with the available fee rates and return the actual values to the dropdown. We can't actually calculate a slow/average/fast fee without a valid proposed transaction (a valid amount, a recipient, etc), so for now it displays no fee when any of those other inputs are invalid. The Send page doesn't have validation yet, so I think we could make it more clear once it does. Or alternatively, I've noticed that on some wallets, they put the fee selection on the Confirm Transaction page instead, which helps make sure those fields are valid.

Fixes IFL-1962
