### PR TITLE
Add i18n command to dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "IF Labs <engineering@iflabs.network> (https://iflabs.network)",
   "main": "app/background.js",
   "scripts": {
-    "dev": "nextron",
+    "dev": "npm run i18n && nextron",
     "build-check": "npm run i18n && nextron build --no-pack",
     "build": "npm run i18n && nextron build",
     "lint": "eslint --fix --config .eslintrc.js .",


### PR DESCRIPTION
On first checkout, you have to run the i18n command to generate compiled locales. This adds the command to dev to avoid the extra step, but we can remove it if it's slowing things down too much.

Fixes #87
