### PR TITLE
Reduce 64px margin to 32px on sidebar images

### DIFF
--- a/renderer/intl/locales/en.json
+++ b/renderer/intl/locales/en.json
@@ -54,9 +54,6 @@
   "6P/bTL": {
     "message": "Connection Type"
   },
-  "6T+v0W": {
-    "message": "Account imported"
-  },
   "8GvVWZ": {
     "message": "Something went wrong, please try again."
   },
@@ -186,6 +183,9 @@
   "YFT4rG": {
     "message": "Keys"
   },
+  "Z4i3fh": {
+    "message": "The Iron Fish Node app supports {languageCount} languages. If your preferred language isn't listed, please reach out and let us know!"
+  },
   "ZhUW3G": {
     "message": "Heap Total"
   },
@@ -203,6 +203,9 @@
   },
   "e6Ph5+": {
     "message": "Address"
+  },
+  "eVlu1R": {
+    "message": "Select language"
   },
   "fF376U": {
     "message": "Current"
@@ -239,9 +242,6 @@
   },
   "tf1lIh": {
     "message": "Free"
-  },
-  "u8X7S9": {
-    "message": "The Iron Fish Node app supports X languages. If your preferred language isn't listed, please reach out and let us know!"
   },
   "uCgp+K": {
     "message": "Blocks Per message"

--- a/renderer/layouts/WithExplanatorySidebar.tsx
+++ b/renderer/layouts/WithExplanatorySidebar.tsx
@@ -38,7 +38,7 @@ export function WithExplanatorySidebar({
           {heading}
         </Heading>
         {description}
-        <Box mt={16}>
+        <Box mt={4}>
           <Image src={imgSrc} alt="" />
         </Box>
       </Box>

--- a/renderer/layouts/WithExplanatorySidebar.tsx
+++ b/renderer/layouts/WithExplanatorySidebar.tsx
@@ -38,7 +38,7 @@ export function WithExplanatorySidebar({
           {heading}
         </Heading>
         {description}
-        <Box mt={4}>
+        <Box mt={8}>
           <Image src={imgSrc} alt="" />
         </Box>
       </Box>

--- a/renderer/pages/address-book/[address]/index.tsx
+++ b/renderer/pages/address-book/[address]/index.tsx
@@ -112,7 +112,7 @@ function SingleContactContent({ address }: { address: string }) {
                   <Text
                     fontSize="sm"
                     maxW="340px"
-                    mb={16}
+                    mb={4}
                     color={COLORS.GRAY_MEDIUM}
                   >
                     With contact names being associated with public addresses,

--- a/renderer/pages/address-book/[address]/index.tsx
+++ b/renderer/pages/address-book/[address]/index.tsx
@@ -112,7 +112,7 @@ function SingleContactContent({ address }: { address: string }) {
                   <Text
                     fontSize="sm"
                     maxW="340px"
-                    mb={4}
+                    mb={8}
                     color={COLORS.GRAY_MEDIUM}
                   >
                     With contact names being associated with public addresses,

--- a/renderer/pages/receive/index.tsx
+++ b/renderer/pages/receive/index.tsx
@@ -85,7 +85,7 @@ export function ReceiveAccountsContent({
           <Heading fontSize="2xl" mb={4}>
             Transaction Details
           </Heading>
-          <Text fontSize="sm" maxW="340px" mb={16} color={COLORS.GRAY_MEDIUM}>
+          <Text fontSize="sm" maxW="340px" mb={4} color={COLORS.GRAY_MEDIUM}>
             You can share your public address with whomever you choose to
             receive payments. Your account will remain completely private, and
             individuals with this public address will not be able to see any of

--- a/renderer/pages/receive/index.tsx
+++ b/renderer/pages/receive/index.tsx
@@ -85,7 +85,7 @@ export function ReceiveAccountsContent({
           <Heading fontSize="2xl" mb={4}>
             Transaction Details
           </Heading>
-          <Text fontSize="sm" maxW="340px" mb={4} color={COLORS.GRAY_MEDIUM}>
+          <Text fontSize="sm" maxW="340px" mb={8} color={COLORS.GRAY_MEDIUM}>
             You can share your public address with whomever you choose to
             receive payments. Your account will remain completely private, and
             individuals with this public address will not be able to see any of

--- a/renderer/pages/send/index.tsx
+++ b/renderer/pages/send/index.tsx
@@ -18,7 +18,7 @@ export default function Send() {
           <Heading fontSize="2xl" mb={4}>
             About Fees
           </Heading>
-          <Text fontSize="sm" maxW="340px" mb={16} color={COLORS.GRAY_MEDIUM}>
+          <Text fontSize="sm" maxW="340px" mb={4} color={COLORS.GRAY_MEDIUM}>
             You can change the fee amount you&apos;d like to pay. However, that
             will directly correlate with the speed with which your transaction
             is picked up by the blockchain.

--- a/renderer/pages/send/index.tsx
+++ b/renderer/pages/send/index.tsx
@@ -18,7 +18,7 @@ export default function Send() {
           <Heading fontSize="2xl" mb={4}>
             About Fees
           </Heading>
-          <Text fontSize="sm" maxW="340px" mb={4} color={COLORS.GRAY_MEDIUM}>
+          <Text fontSize="sm" maxW="340px" mb={8} color={COLORS.GRAY_MEDIUM}>
             You can change the fee amount you&apos;d like to pay. However, that
             will directly correlate with the speed with which your transaction
             is picked up by the blockchain.


### PR DESCRIPTION
Double-checking with Skylar before merging this one, since the Figma has margins of 32px, but the issue specifies 16px.

Fixes IFL-1969

Edit: Chatted on the issue, updated this to 32px