### PR TITLE
Color accounts based on address

### DIFF
--- a/renderer/components/UserAccountsList/UserAccountsList.tsx
+++ b/renderer/components/UserAccountsList/UserAccountsList.tsx
@@ -75,6 +75,12 @@ const sortOptions: Array<SortOption> = [
   },
 ];
 
+function getGradientColor(address: string) {
+  const bigAddress = BigInt(`0x${address}`);
+  const bigLength = BigInt(gradientOptions.length);
+  return gradientOptions[Number(bigAddress % bigLength)];
+}
+
 export function UserAccountsList() {
   const [searchInput, setSearchInput] = useState("");
   const [sortOption, setSortOption] = useState<SortOption>(sortOptions[0]);
@@ -114,11 +120,11 @@ export function UserAccountsList() {
           return item.name.toLowerCase().includes(searchInput.toLowerCase());
         })
         .toSorted(sortOption.sort)
-        .map((account, i) => {
+        .map((account) => {
           return (
             <AccountRow
               key={account.address}
-              color={gradientOptions[i % gradientOptions.length]}
+              color={getGradientColor(account.address)}
               name={account.name}
               balance={account.balances.iron.confirmed}
               address={account.address}

--- a/renderer/intl/locales/en.json
+++ b/renderer/intl/locales/en.json
@@ -54,9 +54,6 @@
   "6P/bTL": {
     "message": "Connection Type"
   },
-  "6T+v0W": {
-    "message": "Account imported"
-  },
   "8GvVWZ": {
     "message": "Something went wrong, please try again."
   },
@@ -186,6 +183,9 @@
   "YFT4rG": {
     "message": "Keys"
   },
+  "Z4i3fh": {
+    "message": "The Iron Fish Node app supports {languageCount} languages. If your preferred language isn't listed, please reach out and let us know!"
+  },
   "ZhUW3G": {
     "message": "Heap Total"
   },
@@ -203,6 +203,9 @@
   },
   "e6Ph5+": {
     "message": "Address"
+  },
+  "eVlu1R": {
+    "message": "Select language"
   },
   "fF376U": {
     "message": "Current"
@@ -239,9 +242,6 @@
   },
   "tf1lIh": {
     "message": "Free"
-  },
-  "u8X7S9": {
-    "message": "The Iron Fish Node app supports X languages. If your preferred language isn't listed, please reach out and let us know!"
   },
   "uCgp+K": {
     "message": "Blocks Per message"


### PR DESCRIPTION
Changes the color of account icons on the Account Overview page based on the account's address, so the color stays stable across sorts.

Since the account address is already a unique integer, it was easy to use that without bringing in a hash function, but maybe in the future we would want to hash in the account name (or at least consider whether we want the coloring to align with the Address Book)

Fixes IFL-1965
