### PR TITLE
Fix SVG warnings about invalid property

### DIFF
--- a/renderer/components/NoteRow/icons/ReceivedIcon.tsx
+++ b/renderer/components/NoteRow/icons/ReceivedIcon.tsx
@@ -22,9 +22,9 @@ export function ReceivedIcon() {
       <path
         d="M17 11.5L17 17L11.5 17"
         stroke={foregroundColor}
-        stroke-width="1.5"
+        strokeWidth="1.5"
       />
-      <path d="M17 17L9 9" stroke={foregroundColor} stroke-width="1.5" />
+      <path d="M17 17L9 9" stroke={foregroundColor} strokeWidth="1.5" />
     </chakra.svg>
   );
 }

--- a/renderer/components/NoteRow/icons/SentIcon.tsx
+++ b/renderer/components/NoteRow/icons/SentIcon.tsx
@@ -14,8 +14,8 @@ export function SentIcon() {
       }}
     >
       <circle cx={13} cy={13} r={13} fill="currentColor" />
-      <path d="M11.5 9H17V14.5" stroke={foregroundColor} stroke-width="1.5" />
-      <path d="M17 9L9 17" stroke={foregroundColor} stroke-width="1.5" />
+      <path d="M11.5 9H17V14.5" stroke={foregroundColor} strokeWidth="1.5" />
+      <path d="M17 9L9 17" stroke={foregroundColor} strokeWidth="1.5" />
     </chakra.svg>
   );
 }

--- a/renderer/intl/locales/en.json
+++ b/renderer/intl/locales/en.json
@@ -54,9 +54,6 @@
   "6P/bTL": {
     "message": "Connection Type"
   },
-  "6T+v0W": {
-    "message": "Account imported"
-  },
   "8GvVWZ": {
     "message": "Something went wrong, please try again."
   },
@@ -186,6 +183,9 @@
   "YFT4rG": {
     "message": "Keys"
   },
+  "Z4i3fh": {
+    "message": "The Iron Fish Node app supports {languageCount} languages. If your preferred language isn't listed, please reach out and let us know!"
+  },
   "ZhUW3G": {
     "message": "Heap Total"
   },
@@ -203,6 +203,9 @@
   },
   "e6Ph5+": {
     "message": "Address"
+  },
+  "eVlu1R": {
+    "message": "Select language"
   },
   "fF376U": {
     "message": "Current"
@@ -239,9 +242,6 @@
   },
   "tf1lIh": {
     "message": "Free"
-  },
-  "u8X7S9": {
-    "message": "The Iron Fish Node app supports X languages. If your preferred language isn't listed, please reach out and let us know!"
   },
   "uCgp+K": {
     "message": "Blocks Per message"


### PR DESCRIPTION
`strokeWidth` instead of `stroke-width`.

As an aside, the icons still looks slightly different from the Figma -- The colors seem to be the same, but I wonder if there's a different overlay affecting the colors somehow.
