### PR TITLE
Remove Account from Create and Import buttons

### DIFF
--- a/renderer/intl/locales/en.json
+++ b/renderer/intl/locales/en.json
@@ -63,6 +63,9 @@
   "9IVf3z": {
     "message": "Account Overview"
   },
+  "9XUYQt": {
+    "message": "Import"
+  },
   "9uOFF3": {
     "message": "Overview"
   },
@@ -161,6 +164,9 @@
   },
   "UTOugV": {
     "message": "Your Assets"
+  },
+  "VzzYJk": {
+    "message": "Create"
   },
   "WWEwrn": {
     "message": "Node Settings"

--- a/renderer/pages/accounts/index.tsx
+++ b/renderer/pages/accounts/index.tsx
@@ -27,10 +27,10 @@ import { formatOre } from "@/utils/ironUtils";
 
 const messages = defineMessages({
   createAccount: {
-    defaultMessage: "Create Account",
+    defaultMessage: "Create",
   },
   importAccount: {
-    defaultMessage: "Import Account",
+    defaultMessage: "Import",
   },
   totalAccountsBalance: {
     defaultMessage: "Total accounts balance",


### PR DESCRIPTION
Since the button is on the Accounts page, we probably don't need to have the text Create Account and Import Account, just Create and Import.

Fixes IFL-1931
