### PR TITLE
Switch default placeholder color to match designs

### DIFF
--- a/renderer/ui/Forms/MnemonicPhrase/MnemonicPhrase.tsx
+++ b/renderer/ui/Forms/MnemonicPhrase/MnemonicPhrase.tsx
@@ -179,9 +179,6 @@ export function MnemonicPhrase({
                   onPaste={handlePaste}
                   borderColor={hasBlur && !value ? COLORS.RED : COLORS.BLACK}
                   placeholder="Empty"
-                  _placeholder={{
-                    color: COLORS.GRAY_MEDIUM,
-                  }}
                   _dark={{
                     borderColor:
                       hasBlur && !value

--- a/renderer/ui/theme/index.ts
+++ b/renderer/ui/theme/index.ts
@@ -45,6 +45,14 @@ const theme = extendTheme({
     }),
     Modal: modalTheme,
   },
+  semanticTokens: {
+    colors: {
+      ["chakra-placeholder-color"]: {
+        _dark: COLORS.DARK_MODE.GRAY_LIGHT,
+        _light: COLORS.GRAY_MEDIUM,
+      },
+    },
+  },
 });
 
 export { createBreakpointArray };


### PR DESCRIPTION
Like the mnemonic input, the color of the Accounts search bar placeholder is also wrong. I removed the mnemonic input override and just set the default in the theme to be the colors we want.

![image](https://github.com/iron-fish/ironfish-node-app/assets/767083/ce77b6bc-44ca-430a-84e1-8a1744a0d351)

Fixes IFL-1929
