### PR TITLE
Update height and color of status indicator

### DIFF
--- a/renderer/components/StatusIndicator/StatusIndicator.tsx
+++ b/renderer/components/StatusIndicator/StatusIndicator.tsx
@@ -15,11 +15,13 @@ function useStatus() {
   return useMemo<{
     status: Status;
     label: string;
+    shortLabel: string;
   }>(() => {
     if (!data || !data.peerNetwork.isReady) {
       return {
         status: "CONNECTING",
         label: "Connecting",
+        shortLabel: "--%",
       };
     }
     if (data.blockSyncer.status === "syncing") {
@@ -30,29 +32,37 @@ function useStatus() {
               data.blockSyncer.syncing.progress * 100
             ).toFixed(2)}%`
           : "Syncing blocks",
+        shortLabel: data.blockSyncer.syncing
+          ? `${Math.floor(data.blockSyncer.syncing.progress * 100)}%`
+          : "--%",
       };
     }
     if (!data.blockchain.synced) {
       return {
         status: "SYNCING",
         label: "Waiting for peers to sync from",
+        shortLabel: "--%",
       };
     }
     if (data.accounts.head.hash !== data.blockchain.head.hash) {
       return {
         status: "SCANNING",
         label: `Scanning blocks: ${data.accounts.head.sequence} / ${data.blockchain.head.sequence}`,
+        shortLabel: `${Math.floor(
+          100 * (data.accounts.head.sequence / data.blockchain.head.sequence),
+        )}%`,
       };
     }
     return {
       status: "SYNCED",
       label: "Synced",
+      shortLabel: "",
     };
   }, [data]);
 }
 
 export function StatusIndicator() {
-  const { status, label } = useStatus();
+  const { status, label, shortLabel } = useStatus();
 
   return (
     <Flex
@@ -94,7 +104,16 @@ export function StatusIndicator() {
           sm: "none",
         }}
       >
-        <IoMdCheckmark size="1.25em" />
+        <Text
+          as="span"
+          color="inherit"
+          _dark={{
+            color: "inherit",
+          }}
+        >
+          {shortLabel}
+        </Text>
+        {status === "SYNCED" && <IoMdCheckmark size="1.25em" />}
       </Box>
     </Flex>
   );

--- a/renderer/components/StatusIndicator/StatusIndicator.tsx
+++ b/renderer/components/StatusIndicator/StatusIndicator.tsx
@@ -61,8 +61,9 @@ export function StatusIndicator() {
       borderRadius={4}
       color={status === "SYNCED" ? COLORS.GREEN_DARK : COLORS.YELLOW_DARK}
       justifyContent="center"
-      py={3}
+      py={2}
       textAlign="center"
+      lineHeight="1.25em"
       _dark={{
         bg:
           status === "SYNCED"
@@ -77,6 +78,9 @@ export function StatusIndicator() {
       <Text
         as="span"
         color="inherit"
+        _dark={{
+          color: "inherit",
+        }}
         display={{
           base: "none",
           sm: "block",


### PR DESCRIPTION
Update the height and dark mode colors of the status indicator to match the designs.

![image](https://github.com/iron-fish/ironfish-node-app/assets/767083/218e9775-70bb-4f61-a849-e9af993b5083)

Also adds a percentage synced indicator the narrow view. If not currently syncing (either "Connecting" or "Waiting for peers"), displays like this for now: (this doesn't have a design)

![image](https://github.com/iron-fish/ironfish-node-app/assets/767083/91028c6a-3190-4bf5-85f1-2fc57d11ae86)


Fixes IFL-1927
Fixes IFL-1928
Fixes IFL-2003