### PR TITLE
Update tab styling to match Figma designs

### DIFF
--- a/renderer/components/ImportAccountModal/ImportAccountModal.tsx
+++ b/renderer/components/ImportAccountModal/ImportAccountModal.tsx
@@ -111,9 +111,7 @@ export function ImportAccountModal({ isOpen, onClose }: Props) {
             >
               <TabList mb={8}>
                 {tabsComponents.map(({ label }, i) => (
-                  <Tab py={2} px={4} mr={4} key={i}>
-                    {label}
-                  </Tab>
+                  <Tab key={i}>{label}</Tab>
                 ))}
               </TabList>
 

--- a/renderer/components/OnboardingFlow/ImportAccount/ImportAccount.tsx
+++ b/renderer/components/OnboardingFlow/ImportAccount/ImportAccount.tsx
@@ -58,13 +58,13 @@ export function ImportAccount() {
 
       <Tabs>
         <TabList mb={8}>
-          <Tab py={2} px={4} mr={4}>
+          <Tab>
             {formatMessage(messages.mnemonicPhrase)}
           </Tab>
-          <Tab py={2} px={4} mr={4}>
+          <Tab>
             {formatMessage(messages.encodedKey)}
           </Tab>
-          <Tab py={2} px={4} mr={4}>
+          <Tab>
             {formatMessage(messages.file)}
           </Tab>
         </TabList>

--- a/renderer/pages/accounts/[account-name]/index.tsx
+++ b/renderer/pages/accounts/[account-name]/index.tsx
@@ -104,15 +104,9 @@ function AccountOverviewContent({ accountName }: { accountName: string }) {
         </VStack>
         <Tabs isLazy defaultIndex={initialTabIndex}>
           <TabList mb={8}>
-            <Tab py={2} px={4} mr={4}>
-              {formatMessage(messages.accountOverview)}
-            </Tab>
-            <Tab py={2} px={4} mr={4}>
-              {formatMessage(messages.keys)}
-            </Tab>
-            <Tab py={2} px={4} mr={4}>
-              {formatMessage(messages.settings)}
-            </Tab>
+            <Tab>{formatMessage(messages.accountOverview)}</Tab>
+            <Tab>{formatMessage(messages.keys)}</Tab>
+            <Tab>{formatMessage(messages.settings)}</Tab>
           </TabList>
 
           <TabPanels>

--- a/renderer/pages/address-book/[address]/index.tsx
+++ b/renderer/pages/address-book/[address]/index.tsx
@@ -93,10 +93,10 @@ function SingleContactContent({ address }: { address: string }) {
         </HStack>
         <Tabs isLazy>
           <TabList mb={8}>
-            <Tab py={2} px={4} mr={4}>
+            <Tab>
               {formatMessage(messages.transactions)}
             </Tab>
-            <Tab py={2} px={4} mr={4}>
+            <Tab>
               {formatMessage(messages.contactSettings)}
             </Tab>
           </TabList>

--- a/renderer/pages/your-node/index.tsx
+++ b/renderer/pages/your-node/index.tsx
@@ -45,15 +45,9 @@ export default function YourNode() {
       <Heading>{formatMessage(messages.yourNode)}</Heading>
       <Tabs isLazy>
         <TabList mb={8}>
-          <Tab py={2} px={4} mr={4}>
-            {formatMessage(messages.overview)}
-          </Tab>
-          <Tab py={2} px={4} mr={4}>
-            {formatMessage(messages.settings)}
-          </Tab>
-          <Tab py={2} px={4} mr={4}>
-            {formatMessage(messages.resources)}
-          </Tab>
+          <Tab>{formatMessage(messages.overview)}</Tab>
+          <Tab>{formatMessage(messages.settings)}</Tab>
+          <Tab>{formatMessage(messages.resources)}</Tab>
         </TabList>
 
         <TabPanels>

--- a/renderer/ui/theme/index.ts
+++ b/renderer/ui/theme/index.ts
@@ -3,6 +3,7 @@ import { defineStyleConfig, extendTheme } from "@chakra-ui/react";
 import { breakpoints, createBreakpointArray } from "./breakpoints";
 import { inputTheme } from "./styleConfigs/input";
 import { modalTheme } from "./styleConfigs/modal";
+import { tabsTheme } from "./styleConfigs/tabs";
 import { COLORS } from "../colors";
 
 // To extend the theme, look through baseTheme from chakra-ui/react,
@@ -43,12 +44,7 @@ const theme = extendTheme({
         },
       },
     }),
-    Tabs: defineStyleConfig({
-      defaultProps: {
-        colorScheme: "muted",
-        size: "sm",
-      },
-    }),
+    Tabs: tabsTheme,
   },
   semanticTokens: {
     colors: {

--- a/renderer/ui/theme/styleConfigs/input.ts
+++ b/renderer/ui/theme/styleConfigs/input.ts
@@ -3,14 +3,12 @@ import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
 
 import { COLORS } from "@/ui/colors";
 
-const {
-  definePartsStyle: defineInputPartsStyle,
-  defineMultiStyleConfig: defineInputMultiStyleConfig,
-} = createMultiStyleConfigHelpers(inputAnatomy.keys);
+const { definePartsStyle, defineMultiStyleConfig } =
+  createMultiStyleConfigHelpers(inputAnatomy.keys);
 
-export const inputTheme = defineInputMultiStyleConfig({
+export const inputTheme = defineMultiStyleConfig({
   variants: {
-    outline: defineInputPartsStyle({
+    outline: definePartsStyle({
       field: {
         _hover: {
           borderColor: COLORS.DARK_MODE.GRAY_LIGHT,

--- a/renderer/ui/theme/styleConfigs/tabs.ts
+++ b/renderer/ui/theme/styleConfigs/tabs.ts
@@ -1,0 +1,24 @@
+import { tabsAnatomy } from "@chakra-ui/anatomy";
+import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
+
+import { COLORS } from "@/ui/colors";
+
+const { definePartsStyle, defineMultiStyleConfig } =
+  createMultiStyleConfigHelpers(tabsAnatomy.keys);
+
+export const tabsTheme = defineMultiStyleConfig({
+  variants: {
+    line: definePartsStyle({
+      tablist: {
+        borderColor: "#DEDFE2",
+        _dark: {
+          borderColor: COLORS.DARK_MODE.GRAY_DARK,
+        },
+      },
+    }),
+  },
+  defaultProps: {
+    colorScheme: "muted",
+    size: "sm",
+  },
+});

--- a/renderer/ui/theme/styleConfigs/tabs.ts
+++ b/renderer/ui/theme/styleConfigs/tabs.ts
@@ -9,6 +9,19 @@ const { definePartsStyle, defineMultiStyleConfig } =
 export const tabsTheme = defineMultiStyleConfig({
   variants: {
     line: definePartsStyle({
+      tab: {
+        fontSize: "xs",
+        color: COLORS.GRAY_MEDIUM,
+        _dark: {
+          color: COLORS.DARK_MODE.GRAY_LIGHT,
+        },
+        _selected: {
+          color: COLORS.BLACK,
+          _dark: {
+            color: COLORS.WHITE,
+          },
+        },
+      },
       tablist: {
         borderColor: "#DEDFE2",
         _dark: {
@@ -16,6 +29,17 @@ export const tabsTheme = defineMultiStyleConfig({
         },
       },
     }),
+  },
+  sizes: {
+    sm: {
+      tab: {
+        lineHeight: "160%",
+        pt: 2,
+        pb: "7px",
+        px: 0,
+        mr: 8,
+      },
+    },
   },
   defaultProps: {
     colorScheme: "muted",


### PR DESCRIPTION
Aside from needing to fix the header sizing, brings the tabs in line with the designs. 

![image](https://github.com/iron-fish/ironfish-node-app/assets/767083/15a8e254-9920-41ca-9d66-71b5ec884543)

Fixes IFL-1937