### PR TITLE
Make address on notes a CopyAddress

### DIFF
--- a/renderer/components/CopyAddress/CopyAddress.tsx
+++ b/renderer/components/CopyAddress/CopyAddress.tsx
@@ -34,7 +34,12 @@ export function CopyAddress({ address, truncate = true, ...rest }: Props) {
       {...rest}
     >
       {truncate ? truncateString(address) : address}
-      <CopyIcon ml={1} transform="translateY(-1px)" />
+      <CopyIcon
+        color={COLORS.GRAY_MEDIUM}
+        _dark={{ color: COLORS.DARK_MODE.GRAY_LIGHT }}
+        ml={1}
+        transform="translateY(-1px)"
+      />
     </Text>
   );
 }

--- a/renderer/components/NoteRow/NoteRow.tsx
+++ b/renderer/components/NoteRow/NoteRow.tsx
@@ -9,12 +9,12 @@ import { ShadowCard } from "@/ui/ShadowCard/ShadowCard";
 import { formatDate } from "@/utils/formatDate";
 import { hexToUTF16String } from "@/utils/hexToUTF16String";
 import { formatOre } from "@/utils/ironUtils";
-import { truncateString } from "@/utils/truncateString";
 
 import { ExpiredIcon } from "./icons/ExpiredIcon";
 import { PendingIcon } from "./icons/PendingIcon";
 import { ReceivedIcon } from "./icons/ReceivedIcon";
 import { SentIcon } from "./icons/SentIcon";
+import { CopyAddress } from "../CopyAddress/CopyAddress";
 
 export function NotesHeadings() {
   return (
@@ -147,7 +147,11 @@ export function NoteRow({
             </GridItem>
             <GridItem display="flex" alignItems="center">
               <Text as="span">
-                {truncateString(type === "send" ? to : from)}
+                <CopyAddress
+                  color={COLORS.BLACK}
+                  _dark={{ color: COLORS.WHITE }}
+                  address={type === "send" ? to : from}
+                />
               </Text>
             </GridItem>
             <GridItem display="flex" alignItems="center">


### PR DESCRIPTION
The address next to notes is a CopyAddress in the Figma designs already.

Fixes IFL-1975
