### PR TITLE
Adds error boundary component

### DIFF
--- a/main/api/manager.ts
+++ b/main/api/manager.ts
@@ -25,12 +25,7 @@ export class Manager {
     const ironfish = await this.getIronfish();
 
     if (!ironfish.isStarted()) {
-      try {
-        await ironfish.init();
-      } catch (err) {
-        console.log("what");
-        throw err;
-      }
+      await ironfish.init();
     }
 
     const rpcClient = await ironfish.rpcClient();

--- a/main/api/manager.ts
+++ b/main/api/manager.ts
@@ -23,6 +23,16 @@ export class Manager {
     if (this._initialState) return this._initialState;
 
     const ironfish = await this.getIronfish();
+
+    if (!ironfish.isStarted()) {
+      try {
+        await ironfish.init();
+      } catch (err) {
+        console.log("what");
+        throw err;
+      }
+    }
+
     const rpcClient = await ironfish.rpcClient();
 
     const accountsResponse = await rpcClient.wallet.getAccounts();

--- a/main/background.ts
+++ b/main/background.ts
@@ -22,7 +22,6 @@ if (isProd) {
 crashReporter.start({ uploadToServer: false });
 
 const ironfish = await manager.getIronfish();
-ironfish.init();
 
 async function createWindow(handler: ReturnType<typeof createIPCHandler>) {
   const window = mainWindow.init();

--- a/renderer/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/renderer/components/ErrorBoundary/ErrorBoundary.tsx
@@ -5,6 +5,7 @@ import { Component, ErrorInfo, ReactNode } from "react";
 import { defineMessages, useIntl } from "react-intl";
 import { useCopyToClipboard } from "usehooks-ts";
 
+import { WithDraggableArea } from "@/layouts/WithDraggableArea";
 import { COLORS } from "@/ui/colors";
 import { useIFToast } from "@/ui/Toast/Toast";
 
@@ -64,48 +65,50 @@ function DefaultFallback({ error }: { error: Error }) {
   const [_, copyToClipboard] = useCopyToClipboard();
   const toast = useIFToast();
   return (
-    <Flex h="100vh" alignItems="center" justifyContent="center" p={4}>
-      <Box maxW="100%" w="800px">
-        <Heading as="h1" textAlign="center" mb={4}>
-          {formatMessage(messages.errorStateHeading)}
-        </Heading>
-        <Text textAlign="center" fontSize="md" mb={6}>
-          {formatMessage(messages.errorStateDescription)}
-        </Text>
-
-        <HStack>
-          <Text
-            as="button"
-            fontWeight="bold"
-            mb={2}
-            onClick={() => {
-              copyToClipboard(error.message);
-              toast({
-                message: formatMessage(messages.errorCopied),
-              });
-            }}
-          >
-            {formatMessage(messages.errorMessage)}
-            <CopyIcon
-              color={COLORS.GRAY_MEDIUM}
-              _dark={{ color: COLORS.DARK_MODE.GRAY_LIGHT }}
-              ml={1}
-              transform="translateY(-1px)"
-            />
+    <WithDraggableArea>
+      <Flex h="100%" alignItems="center" justifyContent="center" p={4}>
+        <Box maxW="100%" w="800px">
+          <Heading as="h1" textAlign="center" mb={4}>
+            {formatMessage(messages.errorStateHeading)}
+          </Heading>
+          <Text textAlign="center" fontSize="md" mb={6}>
+            {formatMessage(messages.errorStateDescription)}
           </Text>
-        </HStack>
 
-        <Code
-          colorScheme="red"
-          p={4}
-          maxH="400px"
-          maxW="100%"
-          w="100%"
-          overflow="auto"
-        >
-          <Text as="pre">{error.message}</Text>
-        </Code>
-      </Box>
-    </Flex>
+          <HStack>
+            <Text
+              as="button"
+              fontWeight="bold"
+              mb={2}
+              onClick={() => {
+                copyToClipboard(error.message);
+                toast({
+                  message: formatMessage(messages.errorCopied),
+                });
+              }}
+            >
+              {formatMessage(messages.errorMessage)}
+              <CopyIcon
+                color={COLORS.GRAY_MEDIUM}
+                _dark={{ color: COLORS.DARK_MODE.GRAY_LIGHT }}
+                ml={1}
+                transform="translateY(-1px)"
+              />
+            </Text>
+          </HStack>
+
+          <Code
+            colorScheme="red"
+            p={4}
+            maxH="400px"
+            maxW="100%"
+            w="100%"
+            overflow="auto"
+          >
+            <Text as="pre">{error.message}</Text>
+          </Code>
+        </Box>
+      </Flex>
+    </WithDraggableArea>
   );
 }

--- a/renderer/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/renderer/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,111 @@
+import { CopyIcon } from "@chakra-ui/icons";
+import { Box, Flex, Text, Heading, Code, HStack } from "@chakra-ui/react";
+import log from "electron-log";
+import { Component, ErrorInfo, ReactNode } from "react";
+import { defineMessages, useIntl } from "react-intl";
+import { useCopyToClipboard } from "usehooks-ts";
+
+import { COLORS } from "@/ui/colors";
+import { useIFToast } from "@/ui/Toast/Toast";
+
+const messages = defineMessages({
+  errorStateHeading: {
+    defaultMessage: "Something went wrong",
+  },
+  errorStateDescription: {
+    defaultMessage:
+      "Please restart the app and try again. If the issue persists, let us know on Discord so we can help troubleshoot.",
+  },
+  errorMessage: {
+    defaultMessage: "Error Message",
+  },
+  errorCopied: {
+    defaultMessage: "Error copied to clipboard",
+  },
+});
+
+type Props = {
+  fallback?: ReactNode;
+  children: ReactNode;
+};
+
+type State = {
+  error: Error | null;
+};
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    log.error(error, info.componentStack);
+  }
+
+  render() {
+    const { children, fallback } = this.props;
+    const { error } = this.state;
+
+    if (error !== null) {
+      return fallback ?? <DefaultFallback error={error} />;
+    }
+
+    return children;
+  }
+}
+
+function DefaultFallback({ error }: { error: Error }) {
+  const { formatMessage } = useIntl();
+  const [_, copyToClipboard] = useCopyToClipboard();
+  const toast = useIFToast();
+  return (
+    <Flex h="100vh" alignItems="center" justifyContent="center" p={4}>
+      <Box maxW="100%" w="800px">
+        <Heading as="h1" textAlign="center" mb={4}>
+          {formatMessage(messages.errorStateHeading)}
+        </Heading>
+        <Text textAlign="center" fontSize="md" mb={6}>
+          {formatMessage(messages.errorStateDescription)}
+        </Text>
+
+        <HStack>
+          <Text
+            as="button"
+            fontWeight="bold"
+            mb={2}
+            onClick={() => {
+              copyToClipboard(error.message);
+              toast({
+                message: formatMessage(messages.errorCopied),
+              });
+            }}
+          >
+            {formatMessage(messages.errorMessage)}
+            <CopyIcon
+              color={COLORS.GRAY_MEDIUM}
+              _dark={{ color: COLORS.DARK_MODE.GRAY_LIGHT }}
+              ml={1}
+              transform="translateY(-1px)"
+            />
+          </Text>
+        </HStack>
+
+        <Code
+          colorScheme="red"
+          p={4}
+          maxH="400px"
+          maxW="100%"
+          w="100%"
+          overflow="auto"
+        >
+          <Text as="pre">{error.message}</Text>
+        </Code>
+      </Box>
+    </Flex>
+  );
+}

--- a/renderer/intl/locales/en.json
+++ b/renderer/intl/locales/en.json
@@ -135,6 +135,9 @@
   "Arxl88": {
     "message": "Outgoing"
   },
+  "AyGP4T": {
+    "message": "Error Message"
+  },
   "BwRLcj": {
     "message": "Your transaction has been submitted. It may take a few minutes until it is confirmed. This transaction will appear in your activity as pending until it is confirmed."
   },
@@ -189,6 +192,9 @@
   "JoB2Ml": {
     "message": "Your account was successfully imported"
   },
+  "JqiqNj": {
+    "message": "Something went wrong"
+  },
   "K340v+": {
     "message": "An error occurred while downloading the snapshot:"
   },
@@ -218,6 +224,9 @@
   },
   "N0KGQj": {
     "message": "Block Graffiti"
+  },
+  "N0bVvU": {
+    "message": "Error copied to clipboard"
   },
   "NDtjP8": {
     "message": "Are you sure? You'll have to re-import this account if you want to use it again."
@@ -314,6 +323,9 @@
   },
   "VzzYJk": {
     "message": "Create"
+  },
+  "WHjylD": {
+    "message": "Please restart the app and try again. If the issue persists, let us know on Discord so we can help troubleshoot."
   },
   "WKCp0D": {
     "message": "Asset"

--- a/renderer/pages/_app.tsx
+++ b/renderer/pages/_app.tsx
@@ -3,6 +3,7 @@ import { AppProps } from "next/app";
 import Head from "next/head";
 import { useIsClient } from "usehooks-ts";
 
+import { ErrorBoundary } from "@/components/ErrorBoundary/ErrorBoundary";
 import { IntlProvider } from "@/intl/IntlProvider";
 import { TRPCProvider } from "@/providers/TRPCProvider";
 import { LoadFonts } from "@/ui/LoadFonts/LoadFonts";
@@ -63,7 +64,9 @@ export default function MyApp({ Component, pageProps }: AppProps) {
       <TRPCProvider>
         <ChakraProvider theme={theme} colorModeManager={systemColorModeManager}>
           <IntlProvider>
-            <Component {...pageProps} />
+            <ErrorBoundary>
+              <Component {...pageProps} />
+            </ErrorBoundary>
           </IntlProvider>
         </ChakraProvider>
       </TRPCProvider>

--- a/renderer/pages/home.tsx
+++ b/renderer/pages/home.tsx
@@ -11,9 +11,15 @@ import { LogoLg } from "@/ui/SVGs/LogoLg";
  */
 export default function Home() {
   const router = useRouter();
+  const {
+    data: initialStateData,
+    error: initialStateError,
+    isLoading: isInitialStateLoading,
+  } = trpcReact.getInitialState.useQuery(undefined, {
+    retry: false,
+    useErrorBoundary: true,
+  });
 
-  const { data: initialStateData, isLoading: isInitialStateLoading } =
-    trpcReact.getInitialState.useQuery();
   const { mutate: startNode } = trpcReact.startNode.useMutation();
 
   // If user has no accounts, go to onboarding
@@ -37,6 +43,8 @@ export default function Home() {
       router.replace("/accounts");
     }
   }, [router, startNode, initialStateData, isInitialStateLoading]);
+
+  console.log({ initialStateData, initialStateError, isInitialStateLoading });
 
   return (
     <Flex h="100vh" justifyContent="center" alignItems="center">

--- a/renderer/pages/home.tsx
+++ b/renderer/pages/home.tsx
@@ -11,14 +11,11 @@ import { LogoLg } from "@/ui/SVGs/LogoLg";
  */
 export default function Home() {
   const router = useRouter();
-  const {
-    data: initialStateData,
-    error: initialStateError,
-    isLoading: isInitialStateLoading,
-  } = trpcReact.getInitialState.useQuery(undefined, {
-    retry: false,
-    useErrorBoundary: true,
-  });
+  const { data: initialStateData, isLoading: isInitialStateLoading } =
+    trpcReact.getInitialState.useQuery(undefined, {
+      retry: false,
+      useErrorBoundary: true,
+    });
 
   const { mutate: startNode } = trpcReact.startNode.useMutation();
 
@@ -43,8 +40,6 @@ export default function Home() {
       router.replace("/accounts");
     }
   }, [router, startNode, initialStateData, isInitialStateLoading]);
-
-  console.log({ initialStateData, initialStateError, isInitialStateLoading });
 
   return (
     <Flex h="100vh" justifyContent="center" alignItems="center">

--- a/renderer/ui/theme/index.ts
+++ b/renderer/ui/theme/index.ts
@@ -1,4 +1,5 @@
 import { defineStyleConfig, extendTheme } from "@chakra-ui/react";
+import { StyleFunctionProps, mode } from "@chakra-ui/theme-tools";
 
 import { breakpoints, createBreakpointArray } from "./breakpoints";
 import { inputTheme } from "./styleConfigs/input";
@@ -21,6 +22,13 @@ const theme = extendTheme({
         500: "white",
       },
     },
+  },
+  styles: {
+    global: (props: StyleFunctionProps) => ({
+      body: {
+        bg: mode("white", COLORS.DARK_MODE.BG)(props),
+      },
+    }),
   },
   breakpoints,
   fonts: {


### PR DESCRIPTION
Adds an error boundary component that displays any uncaught errors that occur.
Also updates the `ironfish.init()` logic to throw if the database is already open, which makes use of the error boundary to display the error to the user.

<img width="1199" alt="Screenshot 2024-01-08 at 9 27 40 PM" src="https://github.com/iron-fish/ironfish-node-app/assets/3639170/b774ed5a-1ea6-46bd-9d09-b52a9db3f72f">
