### PR TITLE
Hide Account Syncing progress when chain is unsynced

### DIFF
--- a/main/api/accounts/index.ts
+++ b/main/api/accounts/index.ts
@@ -92,7 +92,7 @@ export const accountRouter = t.router({
       if (!isBlockchainSynced) {
         return {
           synced: false,
-          progress: 0,
+          progress: null,
         };
       }
 

--- a/renderer/components/AccountSyncingProgress/AccountSyncingProgress.tsx
+++ b/renderer/components/AccountSyncingProgress/AccountSyncingProgress.tsx
@@ -4,6 +4,9 @@ import { defineMessages, useIntl } from "react-intl";
 import { COLORS } from "@/ui/colors";
 
 const messages = defineMessages({
+  syncingNoProgressMessage: {
+    defaultMessage: "Account Syncing",
+  },
   syncingProgressMessage: {
     defaultMessage: "Account Syncing: {progress}%",
   },
@@ -12,7 +15,11 @@ const messages = defineMessages({
   },
 });
 
-export function AccountSyncingProgress({ progress }: { progress: number }) {
+export function AccountSyncingProgress({
+  progress,
+}: {
+  progress: number | null;
+}) {
   const { formatMessage } = useIntl();
 
   return (
@@ -27,8 +34,12 @@ export function AccountSyncingProgress({ progress }: { progress: number }) {
       fontSize="sm"
       textAlign="center"
       p={1}
-    >{`${formatMessage(messages.syncingProgressMessage, {
-      progress: parseFloat((progress * 100).toFixed(2)),
-    })} | ${formatMessage(messages.syncingBalanceMessage)}`}</Box>
+    >{`${
+      progress === null
+        ? formatMessage(messages.syncingNoProgressMessage)
+        : formatMessage(messages.syncingProgressMessage, {
+            progress: parseFloat((progress * 100).toFixed(2)),
+          })
+    } | ${formatMessage(messages.syncingBalanceMessage)}`}</Box>
   );
 }

--- a/renderer/intl/locales/en.json
+++ b/renderer/intl/locales/en.json
@@ -126,9 +126,6 @@
   "9j3hXO": {
     "message": "To"
   },
-  "9pwT3E": {
-    "message": "Need Help? Find us on Discord"
-  },
   "9uOFF3": {
     "message": "Overview"
   },
@@ -155,6 +152,9 @@
   },
   "D5NqQO": {
     "message": "Memo"
+  },
+  "Dh1MGS": {
+    "message": "Account Syncing"
   },
   "FM2S9I": {
     "message": "Set up your node"


### PR DESCRIPTION
When the chain isn't synced, we don't currently have a way to provide a progress estimate. Currently it displays 0% synced, but this change removes the percentaged entirely.

<img width="632" alt="image" src="https://github.com/iron-fish/ironfish-node-app/assets/767083/130d86f5-e3c1-4f86-8a0e-5eb02d932e32">
