### PR TITLE
Fix resetting node and redirect to home after reset

### DIFF
--- a/renderer/components/NodeSettings/NodeSettings.tsx
+++ b/renderer/components/NodeSettings/NodeSettings.tsx
@@ -15,6 +15,7 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/router";
 import { useRef } from "react";
 import { useForm } from "react-hook-form";
 import { defineMessages, useIntl } from "react-intl";
@@ -92,10 +93,11 @@ function NodeSettingsContent({
   initialBlocksPerMessage?: number;
   initialEnableTelemetry?: boolean;
 }) {
+  const router = useRouter();
   const { formatMessage } = useIntl();
   const toast = useIFToast();
 
-  const { mutate: resetNode, isLoading: isResetLoading } =
+  const { mutateAsync: resetNode, isLoading: isResetLoading } =
     trpcReact.resetNode.useMutation();
   const { mutate: setConfig, isLoading: isSetConfigLoading } =
     trpcReact.setConfig.useMutation({
@@ -250,7 +252,9 @@ function NodeSettingsContent({
               <Button
                 colorScheme="red"
                 onClick={() => {
-                  resetNode();
+                  resetNode().then(() => {
+                    router.push("/home");
+                  });
                 }}
                 ml={3}
               >


### PR DESCRIPTION
Reset Node had a bug in it where it wasn't resetting the wallet DB properly. I fixed it to follow the reset CLI command more precisely (creating a temporary node and only opening the wallet DB). Also updated it to redirect to home, which should stick the user back in the "Choose where to sync from" flow.

We considered removing this feature entirely, but it is still occasionally useful as an escape hatch or to test re-downloading snapshots, and it was quick enough to fix. I'd feel more comfortable having it in if the reset was built in to the sdk code though.
