### PR TITLE
Display asset balance deltas on transaction list

### DIFF
--- a/main/api/transactions/utils/formatTransactionsToNotes.ts
+++ b/main/api/transactions/utils/formatTransactionsToNotes.ts
@@ -1,4 +1,5 @@
 import { RpcAsset, RpcClient, RpcWalletTransaction } from "@ironfish/sdk";
+import log from "electron-log";
 
 import { IRON_ID } from "../../../../shared/constants";
 import { TransactionNote } from "../../../../shared/types";
@@ -33,12 +34,7 @@ export async function getTransactionNotes(
 
   const transactionNotes: Array<TransactionNote> =
     transaction.notes
-      ?.filter((_note) => {
-        // @todo: Add ability to filter out self-send notes (to hide noisy change notes).
-        // Consider that mining rewards are self-sends.
-        return true;
-      })
-      .sort((note) => (note.assetId === IRON_ID ? -1 : 1))
+      ?.sort((note) => (note.assetId === IRON_ID ? -1 : 1))
       .map((note) => {
         return {
           assetName: assetLookup[note.assetId]?.name ?? "Unknown",
@@ -75,13 +71,90 @@ export async function formatTransactionsToNotes(
   const transactionNotes: Array<TransactionNote> = [];
 
   for (const tx of transactions) {
-    const notes = await getTransactionNotes(
-      client,
-      tx,
-      accountName,
-      assetLookup,
-    );
-    transactionNotes.push(...notes);
+    // Ignore transactions without at least 1 note
+    if (!tx.notes || tx.notes.length === 0) {
+      log.warn(`Unexpected transaction with 0 or undefined notes: ${tx.hash}`);
+      continue;
+    }
+    const firstNote = tx.notes[0];
+
+    // True if any asset balance is non-zero, ignoring the transaction fee (if current account is sender)
+    const anyNonZero = tx.assetBalanceDeltas.some((abd) => {
+      const deltaWithoutFee =
+        abd.delta.startsWith("-") && abd.assetId === IRON_ID
+          ? (BigInt(abd.delta) + BigInt(tx.fee)).toString()
+          : abd.delta;
+
+      return deltaWithoutFee !== "0";
+    });
+
+    // Make a TransactionNote for each asset balance delta
+    for (const abd of tx.assetBalanceDeltas) {
+      const asset = assetLookup[abd.assetId];
+
+      const deltaWithoutFee =
+        abd.delta.startsWith("-") && abd.assetId === IRON_ID
+          ? (BigInt(abd.delta) + BigInt(tx.fee)).toString()
+          : abd.delta;
+      const absoluteDeltaWithoutFee = deltaWithoutFee.replace("-", "");
+
+      // We want to show at least one TransactionNote for every transaction. For note-combining transactions,
+      // all deltas will be 0, so we'll show 0-value deltas. But in cases where we have at least one non-zero
+      // delta, we can hide the 0-value deltas (notably this happens for $IRON fees on custom asset transactions)
+      if (anyNonZero && absoluteDeltaWithoutFee === "0") {
+        continue;
+      }
+
+      // Ignoring self-sends (change notes), build a list of note recipients
+      let to;
+      const owners = [
+        ...new Set(
+          tx.notes
+            .filter(
+              (n) => n.assetId === abd.assetId && n.owner !== firstNote.sender,
+            )
+            .map((n) => n.owner),
+        ).values(),
+      ];
+      if (owners.length === 0) {
+        to = firstNote.sender;
+      } else if (owners.length === 1) {
+        to = owners[0];
+      } else {
+        to = owners;
+      }
+
+      // Ignoring empty memos, build a list of unique memos
+      let memo;
+      const memos = [
+        ...new Set(
+          tx.notes
+            .filter((n) => n.assetId === abd.assetId && n.memo)
+            .map((n) => n.memo),
+        ).values(),
+      ];
+      if (memos.length === 0) {
+        memo = "";
+      } else if (memos.length === 1) {
+        memo = memos[0];
+      } else {
+        memo = memos;
+      }
+
+      transactionNotes.push({
+        accountName,
+        assetName: asset.name,
+        from: firstNote.sender,
+        to: to,
+        status: tx.status,
+        timestamp: tx.timestamp,
+        transactionHash: tx.hash,
+        type: tx.type,
+        value: absoluteDeltaWithoutFee,
+        noteHash: "",
+        memo: memo,
+      });
+    }
   }
 
   return transactionNotes;

--- a/renderer/components/NoteRow/NoteRow.tsx
+++ b/renderer/components/NoteRow/NoteRow.tsx
@@ -45,6 +45,12 @@ const messages = defineMessages({
   expired: {
     defaultMessage: "Expired",
   },
+  multipleRecipients: {
+    defaultMessage: "Multiple recipients",
+  },
+  multipleMemos: {
+    defaultMessage: "Multiple memos",
+  },
 });
 
 export function NotesHeadings() {
@@ -108,6 +114,30 @@ function getNoteStatusDisplay(
   return { icon: <PendingIcon />, message: messages.pending };
 }
 
+function NoteTo({
+  to,
+  from,
+  type,
+}: {
+  to: string | string[];
+  from: string;
+  type: TransactionType;
+}) {
+  const { formatMessage } = useIntl();
+
+  if (Array.isArray(to)) {
+    return <Text as="span">{formatMessage(messages.multipleRecipients)}</Text>;
+  }
+
+  return (
+    <CopyAddress
+      color={COLORS.BLACK}
+      _dark={{ color: COLORS.WHITE }}
+      address={type === "send" ? to : from}
+    />
+  );
+}
+
 export function NoteRow({
   accountName,
   assetName,
@@ -126,10 +156,10 @@ export function NoteRow({
   value: string;
   timestamp: number;
   from: string;
-  to: string;
+  to: string | string[];
   type: TransactionType;
   status: TransactionStatus;
-  memo: string;
+  memo: string | string[];
   transactionHash: string;
   /**
    * Render the row as if it were a transaction (link it to the transaction details page,
@@ -181,18 +211,20 @@ export function NoteRow({
             </GridItem>
             <GridItem display="flex" alignItems="center">
               <Text as="span">
-                <CopyAddress
-                  color={COLORS.BLACK}
-                  _dark={{ color: COLORS.WHITE }}
-                  address={type === "send" ? to : from}
-                />
+                <NoteTo to={to} from={from} type={type} />
               </Text>
             </GridItem>
             <GridItem display="flex" alignItems="center">
               <Text as="span">{formatDate(timestamp)}</Text>
             </GridItem>
             <GridItem display="flex" alignItems="center">
-              <Text as="span">{memo || "—"}</Text>
+              <Text as="span">
+                {!memo
+                  ? "—"
+                  : Array.isArray(memo)
+                  ? formatMessage(messages.multipleMemos)
+                  : memo}
+              </Text>
             </GridItem>
             {asTransaction && (
               <GridItem

--- a/renderer/intl/locales/en.json
+++ b/renderer/intl/locales/en.json
@@ -231,6 +231,9 @@
   "LP4H/8": {
     "message": "Scanning blocks: {sequence} / {totalSequence}"
   },
+  "LPlno7": {
+    "message": "Multiple recipients"
+  },
   "LRJJAc": {
     "message": "Transaction Hash"
   },
@@ -299,6 +302,9 @@
   },
   "RahCRH": {
     "message": "Expired"
+  },
+  "Ry+/2j": {
+    "message": "Multiple memos"
   },
   "S+nmcq": {
     "message": "Transaction Information"

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -5,11 +5,11 @@ export type TransactionNote = {
   value: string;
   timestamp: number;
   from: string;
-  to: string;
+  to: string | string[];
   transactionHash: string;
   type: TransactionType;
   status: TransactionStatus;
-  memo: string;
+  memo: string | string[];
   noteHash: string;
   accountName: string;
 };


### PR DESCRIPTION
I started this with the goal of fixing change notes from displaying on the transaction list. I didn't intend to change the data as much as I did, but I kept running into more edge cases involving multi asset transactions and note combining.

The current solution I landed on is displaying asset balance deltas, and displaying "Multiple memos" and "Multiple recipients" for transactions that involve sending the same asset to multiple addresses.

So, a transaction that involves multiple assets will still display multiple rows, but there shouldn't be any 0-value rows displayed unless a transaction only includes 0-value rows. Fees are still removed since we didn't previously display them.

### Example of multiple recipient/multiple memo transaction

<img width="619" alt="multiple" src="https://github.com/iron-fish/ironfish-node-app/assets/767083/d5496b97-c519-4bcd-ac2e-fe67afe2bfd6">
