### PR TITLE
Fix theme not applying inside LightMode component

### DIFF
--- a/renderer/intl/locales/en.json
+++ b/renderer/intl/locales/en.json
@@ -138,6 +138,9 @@
   "9j3hXO": {
     "message": "To"
   },
+  "9pwT3E": {
+    "message": "Need Help? Find us on Discord"
+  },
   "9uOFF3": {
     "message": "Overview"
   },

--- a/renderer/layouts/OnboardingLayout.tsx
+++ b/renderer/layouts/OnboardingLayout.tsx
@@ -1,14 +1,14 @@
 import {
   Box,
   Flex,
+  GlobalStyle,
   HStack,
   LightMode,
   Text,
   VStack,
-  useColorMode,
 } from "@chakra-ui/react";
 import Image from "next/image";
-import { ReactNode, useEffect } from "react";
+import { ReactNode } from "react";
 import { defineMessages, useIntl } from "react-intl";
 
 import bigOnboardingFish from "@/images/big-onboarding-fish.svg";
@@ -23,17 +23,11 @@ const messages = defineMessages({
 });
 
 export function OnboardingLayout({ children }: { children: ReactNode }) {
-  const { colorMode, toggleColorMode } = useColorMode();
   const { formatMessage } = useIntl();
-
-  useEffect(() => {
-    if (colorMode === "dark") {
-      toggleColorMode();
-    }
-  }, [colorMode, toggleColorMode]);
 
   return (
     <LightMode>
+      <GlobalStyle />
       <WithDraggableArea>
         <Box position="fixed" inset={0} pointerEvents="none" overflow="hidden">
           <Box

--- a/renderer/ui/theme/index.ts
+++ b/renderer/ui/theme/index.ts
@@ -27,6 +27,7 @@ const theme = extendTheme({
     global: (props: StyleFunctionProps) => ({
       body: {
         bg: mode("white", COLORS.DARK_MODE.BG)(props),
+        color: mode(COLORS.BLACK, COLORS.WHITE)(props),
       },
     }),
   },
@@ -56,6 +57,10 @@ const theme = extendTheme({
   },
   semanticTokens: {
     colors: {
+      ["chakra-body-text"]: {
+        _dark: COLORS.WHITE,
+        _light: COLORS.BLACK,
+      },
       ["chakra-placeholder-color"]: {
         _dark: COLORS.DARK_MODE.GRAY_LIGHT,
         _light: COLORS.GRAY_MEDIUM,


### PR DESCRIPTION
It's a bit ridiculous how many separate places we need to override this, but this fixes the issue with color not applying to text and headings inside the Onboarding light mode component.
