### PR TITLE
Fix transactions not displaying pending status

### DIFF
--- a/renderer/components/NoteRow/NoteRow.tsx
+++ b/renderer/components/NoteRow/NoteRow.tsx
@@ -89,7 +89,7 @@ function getNoteStatusDisplay(
   status: TransactionStatus,
   asTransaction: boolean,
 ): { icon: ReactNode; message: MessageDescriptor } {
-  if (asTransaction || status === "confirmed") {
+  if (!asTransaction || status === "confirmed") {
     if (type === "send") {
       return { icon: <SentIcon />, message: messages.sent };
     } else if (type === "receive" || type === "miner") {

--- a/renderer/intl/locales/en.json
+++ b/renderer/intl/locales/en.json
@@ -138,6 +138,9 @@
   "9j3hXO": {
     "message": "To"
   },
+  "9pwT3E": {
+    "message": "Need Help? Find us on Discord"
+  },
   "9uOFF3": {
     "message": "Overview"
   },


### PR DESCRIPTION
The conditional was flipped: when we're displaying notes, we ignore the pending status, but when we're displaying transactions, we show it.
