### PR TITLE
Fix parseIron when passing in a number

### DIFF
--- a/renderer/intl/locales/en.json
+++ b/renderer/intl/locales/en.json
@@ -138,6 +138,9 @@
   "9j3hXO": {
     "message": "To"
   },
+  "9pwT3E": {
+    "message": "Need Help? Find us on Discord"
+  },
   "9uOFF3": {
     "message": "Overview"
   },

--- a/renderer/utils/ironUtils.ts
+++ b/renderer/utils/ironUtils.ts
@@ -18,7 +18,9 @@ export function parseOre(value: string | number) {
  * Converts a number value in $IRON to a value in Ore.
  */
 export function parseIron(value: string | number) {
-  const asString = String(value);
+  // Converts scientific notation to fixed decimals
+  const asString =
+    typeof value === "number" ? value.toFixed(ASSET_DECIMALS) : value;
   try {
     return parseFixed(asString, ASSET_DECIMALS).toNumber();
   } catch {


### PR DESCRIPTION
The ethersproject/bignumber library unfortunately doesn't like the scientific notation that JS numbers get converted to below a certain threshold. We can just call toFixed on it, but I'm wondering if we should rethink how we're storing the underlying amounts to avoid conversion issues.
