### PR TITLE
i18n nav and accounts header

### DIFF
--- a/renderer/intl/locales/en.json
+++ b/renderer/intl/locales/en.json
@@ -138,6 +138,9 @@
   "9j3hXO": {
     "message": "To"
   },
+  "9pwT3E": {
+    "message": "Need Help? Find us on Discord"
+  },
   "9uOFF3": {
     "message": "Overview"
   },
@@ -179,6 +182,9 @@
   },
   "FnRTEV": {
     "message": "Average"
+  },
+  "FvanT6": {
+    "message": "Accounts"
   },
   "GHoUMq": {
     "message": "Account Syncing: {progress}%"
@@ -593,6 +599,9 @@
   },
   "wsALI4": {
     "message": "Enter Encoded Key"
+  },
+  "xP64Lw": {
+    "message": "Address Book"
   },
   "xkLxAx": {
     "message": "Account Created"

--- a/renderer/layouts/MainLayout.tsx
+++ b/renderer/layouts/MainLayout.tsx
@@ -9,6 +9,7 @@ import {
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import { createContext, ReactNode, useContext, useState } from "react";
+import { defineMessages, useIntl } from "react-intl";
 
 import { BackButton } from "@/components/BackButton/BackButton";
 import { LanguageSelector } from "@/components/LanguageSelector/LanguageSelector";
@@ -27,34 +28,55 @@ import { YourNode } from "@/ui/SVGs/YourNode";
 
 import { WithDraggableArea } from "./WithDraggableArea";
 
+const messages = defineMessages({
+  accounts: {
+    defaultMessage: "Accounts",
+  },
+  send: {
+    defaultMessage: "Send",
+  },
+  receive: {
+    defaultMessage: "Receive",
+  },
+  addressBook: {
+    defaultMessage: "Address Book",
+  },
+  yourNode: {
+    defaultMessage: "Your Node",
+  },
+  releaseNotes: {
+    defaultMessage: "Release Notes",
+  },
+});
+
 const LINKS = [
   {
-    label: "Accounts",
+    label: messages.accounts,
     href: "/accounts",
     icon: <House />,
   },
   {
-    label: "Send $IRON",
+    label: messages.send,
     href: "/send",
     icon: <ArrowSend />,
   },
   {
-    label: "Receive $IRON",
+    label: messages.receive,
     href: "/receive",
     icon: <ArrowReceive />,
   },
   {
-    label: "Address Book",
+    label: messages.addressBook,
     href: "/address-book",
     icon: <AddressBook />,
   },
   {
-    label: "Your Node",
+    label: messages.yourNode,
     href: "/your-node",
     icon: <YourNode />,
   },
   {
-    label: "Release Notes",
+    label: messages.releaseNotes,
     href: "/release-notes",
     icon: <ReleaseNotes />,
   },
@@ -85,6 +107,7 @@ function ResponsiveLogo() {
 
 function Sidebar() {
   const router = useRouter();
+  const { formatMessage } = useIntl();
 
   return (
     <Flex flexDirection="column" alignItems="stretch" w="100%">
@@ -123,7 +146,7 @@ function Sidebar() {
                     md: "block",
                   }}
                 >
-                  {label}
+                  {formatMessage(label)}
                 </Text>
               </HStack>
             </ChakraLink>

--- a/renderer/pages/accounts/index.tsx
+++ b/renderer/pages/accounts/index.tsx
@@ -26,6 +26,9 @@ import { ImportAccount } from "@/ui/SVGs/ImportAccount";
 import { formatOre } from "@/utils/ironUtils";
 
 const messages = defineMessages({
+  accountsHeader: {
+    defaultMessage: "Accounts",
+  },
   createAccount: {
     defaultMessage: "Create",
   },
@@ -125,7 +128,9 @@ export default function Accounts() {
       <MainLayout>
         <VStack mb={10} alignItems="stretch">
           <HStack>
-            <Heading flexGrow={1}>Accounts</Heading>
+            <Heading flexGrow={1}>
+              {formatMessage(messages.accountsHeader)}
+            </Heading>
             <CreateImportActions />
           </HStack>
           <Box>


### PR DESCRIPTION
i18n the navigation sidebar and Accounts page header, and remove "$IRON" from the send and receive links on the side.

Fixes IFL-2100
Fixes IFL-2099
Fixes IFL-2098
