### PR TITLE
Update h2 sizing and fix a couple more styles

### DIFF
--- a/renderer/pages/accounts/index.tsx
+++ b/renderer/pages/accounts/index.tsx
@@ -60,7 +60,7 @@ function CreateImportActions() {
       <HStack
         display={{
           base: "none",
-          lg: "flex",
+          md: "flex",
         }}
         gap={4}
       >
@@ -77,7 +77,7 @@ function CreateImportActions() {
       <Box
         display={{
           base: "flex",
-          lg: "none",
+          md: "none",
         }}
       >
         <Menu>
@@ -126,22 +126,29 @@ export default function Accounts() {
   return (
     <>
       <MainLayout>
-        <VStack mb={10} alignItems="stretch">
-          <HStack>
-            <Heading flexGrow={1}>
+        <HStack alignItems="start" justifyContent="space-between" mb={10}>
+          <VStack gap={0} alignItems="stretch">
+            <Heading fontSize={28} flexGrow={1} lineHeight="160%">
               {formatMessage(messages.accountsHeader)}
             </Heading>
-            <CreateImportActions />
-          </HStack>
-          <Box>
-            <Text fontSize="md" as="span" color={COLORS.GRAY_MEDIUM} mr={1}>
-              {formatMessage(messages.totalAccountsBalance)}:{" "}
-            </Text>
-            <Text fontSize="md" as="span" fontWeight="bold">
-              {totalBalance !== null ? formatOre(totalBalance) : "—"} $IRON
-            </Text>
-          </Box>
-        </VStack>
+            <Box>
+              <Text
+                fontSize="md"
+                as="span"
+                color={COLORS.GRAY_MEDIUM}
+                _dark={{ color: COLORS.GRAY_MEDIUM }}
+                mr={1}
+              >
+                {formatMessage(messages.totalAccountsBalance)}:{" "}
+              </Text>
+              <Text fontSize="md" as="span" fontWeight="bold">
+                {totalBalance !== null ? formatOre(totalBalance) : "—"} $IRON
+              </Text>
+            </Box>
+          </VStack>
+          <CreateImportActions />
+        </HStack>
+
         <UserAccountsList />
       </MainLayout>
     </>

--- a/renderer/pages/address-book/[address]/index.tsx
+++ b/renderer/pages/address-book/[address]/index.tsx
@@ -75,14 +75,13 @@ function SingleContactContent({ address }: { address: string }) {
       }}
     >
       <Box>
-        <HStack mb={4} gap={4} alignItems="center">
-          <FishIcon bg={getGradientByOrder(contactData.order ?? 0)} mr={2} />
-          <Heading>{contactData.name}</Heading>
-          <CopyAddress
-            address={contactData.address}
-            transform="translateY(0.4em)"
-          />
+        <HStack mb={3} gap={4} alignItems="center">
+          <FishIcon bg={getGradientByOrder(contactData.order ?? 0)} />
+          <Heading fontSize={28} lineHeight="160%">
+            {contactData.name}
+          </Heading>
           <PillButton
+            ml={4}
             size="sm"
             onClick={(e) => {
               e.preventDefault();
@@ -93,6 +92,7 @@ function SingleContactContent({ address }: { address: string }) {
             {formatMessage(messages.send)}
           </PillButton>
         </HStack>
+        <CopyAddress address={contactData.address} truncate={false} />
         <Tabs isLazy>
           <TabList mb={8}>
             <Tab>{formatMessage(messages.transactions)}</Tab>

--- a/renderer/pages/address-book/index.tsx
+++ b/renderer/pages/address-book/index.tsx
@@ -16,6 +16,9 @@ import { PillButton } from "@/ui/PillButton/PillButton";
 import { CreateAccount } from "@/ui/SVGs/CreateAccount";
 
 const messages = defineMessages({
+  addressBook: {
+    defaultMessage: "Address Book",
+  },
   noContacts: {
     defaultMessage: "You don't have any contacts",
   },
@@ -42,8 +45,10 @@ export default function AddressBookPage() {
 
   return (
     <MainLayout>
-      <HStack mb={10}>
-        <Heading flexGrow={1}>Address Book</Heading>
+      <HStack mb={8}>
+        <Heading fontSize={28} lineHeight="160%" flexGrow={1}>
+          {formatMessage(messages.addressBook)}
+        </Heading>
         <HStack>
           <PillButton
             size="sm"

--- a/renderer/pages/receive/index.tsx
+++ b/renderer/pages/receive/index.tsx
@@ -72,7 +72,9 @@ export function ReceiveAccountsContent({
 
   return (
     <MainLayout>
-      <Heading mb={5}>{formatMessage(messages.receiveHeading)}</Heading>
+      <Heading fontSize={28} lineHeight="160%" mb={5}>
+        {formatMessage(messages.receiveHeading)}
+      </Heading>
 
       <WithExplanatorySidebar
         heading={formatMessage(messages.transactionDetailsHeading)}

--- a/renderer/pages/release-notes/index.tsx
+++ b/renderer/pages/release-notes/index.tsx
@@ -55,7 +55,9 @@ export default function ReleaseNotes() {
   return (
     <MainLayout>
       <HStack alignItems="center" mb={10} gap={6}>
-        <Heading>{formatMessage(messages.releaseNotes)}</Heading>
+        <Heading fontSize={28} lineHeight="160%">
+          {formatMessage(messages.releaseNotes)}
+        </Heading>
         <Box
           background={COLORS.GRAY_LIGHT}
           borderRadius="5px"

--- a/renderer/pages/send/index.tsx
+++ b/renderer/pages/send/index.tsx
@@ -25,7 +25,9 @@ export default function Send() {
 
   return (
     <MainLayout>
-      <Heading mb={5}>{formatMessage(messages.heading)}</Heading>
+      <Heading fontSize={28} lineHeight="160%" mb={5}>
+        {formatMessage(messages.heading)}
+      </Heading>
       <Flex gap={16}>
         <Box maxW="592px" w="100%">
           <SendAssetsForm />
@@ -34,7 +36,13 @@ export default function Send() {
           <Heading fontSize="2xl" mb={4}>
             {formatMessage(messages.aboutFees)}
           </Heading>
-          <Text fontSize="sm" maxW="340px" mb={8} color={COLORS.GRAY_MEDIUM}>
+          <Text
+            fontSize="sm"
+            maxW="340px"
+            mb={8}
+            color={COLORS.GRAY_MEDIUM}
+            _dark={{ color: COLORS.DARK_MODE.GRAY_LIGHT }}
+          >
             {formatMessage(messages.feeAmount)}
           </Text>
           <Image src={treasureChest} alt="" />

--- a/renderer/pages/your-node/index.tsx
+++ b/renderer/pages/your-node/index.tsx
@@ -42,9 +42,11 @@ export default function YourNode() {
 
   return (
     <MainLayout>
-      <Heading>{formatMessage(messages.yourNode)}</Heading>
+      <Heading fontSize={28} lineHeight="160%">
+        {formatMessage(messages.yourNode)}
+      </Heading>
       <Tabs isLazy>
-        <TabList mb={8}>
+        <TabList mt={3} mb={8}>
           <Tab>{formatMessage(messages.overview)}</Tab>
           <Tab>{formatMessage(messages.settings)}</Tab>
           <Tab>{formatMessage(messages.resources)}</Tab>


### PR DESCRIPTION
Updates all the h2 sizing to match Figma, fixes another missing i18n string (this was already used elsewhere, so no changes to the locale files needed), and tweaks styles in a couple more places.
