### PR TITLE
Style navbar according to Figma designs

### DIFF
--- a/renderer/components/LanguageSelector/LanguageSelector.tsx
+++ b/renderer/components/LanguageSelector/LanguageSelector.tsx
@@ -113,6 +113,14 @@ export function LanguageSelector() {
           bg: COLORS.DARK_MODE.GRAY_MEDIUM,
           color: COLORS.DARK_MODE.GRAY_LIGHT,
         }}
+        width={{
+          base: "34px",
+          md: "100%",
+        }}
+        height={{
+          base: "34px",
+          md: "100%",
+        }}
         onClick={onOpen}
       >
         <MdOutlineLanguage />

--- a/renderer/components/StatusIndicator/StatusIndicator.tsx
+++ b/renderer/components/StatusIndicator/StatusIndicator.tsx
@@ -112,6 +112,14 @@ export function StatusIndicator() {
       py={2}
       textAlign="center"
       lineHeight="1.25em"
+      width={{
+        base: "34px",
+        md: "100%",
+      }}
+      height={{
+        base: "34px",
+        md: "100%",
+      }}
       _dark={{
         bg:
           status === "SYNCED"

--- a/renderer/layouts/MainLayout.tsx
+++ b/renderer/layouts/MainLayout.tsx
@@ -3,9 +3,9 @@ import {
   GridItem,
   Box,
   VStack,
-  Text,
   HStack,
   Flex,
+  Heading,
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import { createContext, ReactNode, useContext, useState } from "react";
@@ -122,38 +122,50 @@ function Sidebar() {
               key={href}
               href={href}
               w="100%"
-              py={3}
-              px={2}
+              height="40px"
+              px={4}
               borderRadius={4}
               bg={isActive ? COLORS.GRAY_LIGHT : "transparent"}
+              color={isActive ? COLORS.BLACK : COLORS.GRAY_MEDIUM}
               _dark={{
                 bg: isActive ? COLORS.DARK_MODE.GRAY_MEDIUM : "transparent",
+                color: isActive ? COLORS.WHITE : COLORS.DARK_MODE.GRAY_LIGHT,
               }}
               _hover={{
                 bg: COLORS.GRAY_LIGHT,
+                color: COLORS.BLACK,
                 _dark: {
                   bg: COLORS.DARK_MODE.GRAY_MEDIUM,
+                  color: COLORS.WHITE,
                 },
               }}
+              role="group"
             >
-              <HStack>
-                <Box w="30px" display="flex" justifyContent="center">
+              <HStack gap={4} h="100%">
+                <Box
+                  display="flex"
+                  justifyContent="center"
+                  width="24px"
+                  color={COLORS.BLACK}
+                  _dark={{ color: COLORS.WHITE }}
+                >
                   {icon}
                 </Box>
-                <Text
+                <Heading
+                  fontSize="sm"
                   display={{
                     base: "none",
                     md: "block",
                   }}
                 >
                   {formatMessage(label)}
-                </Text>
+                </Heading>
               </HStack>
             </ChakraLink>
           );
         })}
       </VStack>
-      <VStack alignItems="stretch" gap={3}>
+      <VStack alignItems="center" gap={4}>
         <StatusIndicator />
         <LanguageSelector />
         <DarkModeSwitch />
@@ -196,8 +208,12 @@ export default function MainLayout({ children, backLinkProps }: Props) {
             base: "auto",
             md: "265px",
           }}
-          p={4}
+          px={4}
           pt="50px"
+          pb={{
+            base: 8,
+            md: 6,
+          }}
           display="flex"
           alignItems="stretch"
         >

--- a/renderer/ui/DarkModeSwitch/DarkModeSwitch.tsx
+++ b/renderer/ui/DarkModeSwitch/DarkModeSwitch.tsx
@@ -23,12 +23,14 @@ export const DarkModeSwitch = () => {
       aria-label="Toggle Color Mode"
       onClick={toggleColorMode}
       bg={COLORS.GRAY_LIGHT}
-      w="100%"
+      w={{
+        base: "34px",
+        md: "100%",
+      }}
       h={{
-        base: "80px",
+        base: "60px",
         md: "auto",
       }}
-      minWidth="40px"
       p={1}
       position="relative"
       borderRadius="5px"

--- a/renderer/ui/SVGs/House.tsx
+++ b/renderer/ui/SVGs/House.tsx
@@ -1,10 +1,18 @@
 export function House() {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={20} height={17} fill="none">
-      <path
-        fill="currentColor"
-        d="m10 2.69 5 4.5V15h-2V9H7v6H5V7.19l5-4.5ZM10 0 0 9h3v8h6v-6h2v6h6V9h3L10 0Z"
-      />
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+    >
+      <g>
+        <path
+          d="M12 5.69L17 10.19V18H15V12H9V18H7V10.19L12 5.69ZM12 3L2 12H5V20H11V14H13V20H19V12H22L12 3Z"
+          fill="currentColor"
+        />
+      </g>
     </svg>
   );
 }


### PR DESCRIPTION
Update the navbar styles to match the Figma designs.

### Normal

<img width="1010" alt="image" src="https://github.com/iron-fish/ironfish-node-app/assets/767083/6bb5535e-b614-40b0-a13e-e328e70484b5">

### Minimized

<img width="596" alt="image" src="https://github.com/iron-fish/ironfish-node-app/assets/767083/263edcff-5e54-492e-8e9b-cf81491cf39a">
