### PR TITLE
Prevent window from being refreshed

### DIFF
--- a/main/main-window.ts
+++ b/main/main-window.ts
@@ -140,6 +140,12 @@ class MainWindow {
       return { action: "deny" };
     });
 
+    // We're intentially preventing the browser from handling unload events (e.g. close, refresh)
+    // so we have to handle closing the window manually.
+    this.window.on("close", () => {
+      this.window?.destroy();
+    });
+
     this.window.on("closed", () => {
       this.window = null;
       const [promise, resolve] = PromiseUtils.split<BrowserWindow>();

--- a/renderer/pages/_app.tsx
+++ b/renderer/pages/_app.tsx
@@ -1,6 +1,7 @@
 import { ChakraProvider } from "@chakra-ui/react";
 import { AppProps } from "next/app";
 import Head from "next/head";
+import { useEffect } from "react";
 import { useIsClient } from "usehooks-ts";
 
 import { ErrorBoundary } from "@/components/ErrorBoundary/ErrorBoundary";
@@ -50,6 +51,17 @@ const systemColorModeManager = new SystemColorModeManager();
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   const isClient = useIsClient();
+
+  useEffect(() => {
+    // Prevent window from unloading (i.e. closing or being reloaded). This is due to dynamic routes not
+    // being statically generated, which causes the app to 404 if the user reloads on a dynamic route.
+    // Closing the window is handled by the main process, which listens for the "close" event and destroys
+    // the window.
+    window.addEventListener("beforeunload", (e) => {
+      e.preventDefault();
+      e.returnValue = true;
+    });
+  }, []);
 
   if (!isClient) {
     return null;


### PR DESCRIPTION
There's an issue with dynamic routes since Nextron creates a static build and those aren't generated statically.

If you refresh the page in a static route, the page will 404. This prevents the browser from handling refreshes or closing the window. It moves the close handler to the Electron process, which destroys the window when it's closed.