### PR TITLE
Bump version to v2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "ironfish-node-app",
   "description": "Iron Fish Node App",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "IF Labs <engineering@iflabs.network> (https://iflabs.network)",
   "main": "app/background.js",
   "scripts": {


### PR DESCRIPTION
v2.0.0 is out, so we can bump to v2.0.1 now.