### PR TITLE
Add RemoveAccountModal to replace default-styled alert dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "extract:i18n": "formatjs extract renderer/{pages,components,sections,layouts,ui}/**/*.{js,ts,tsx} --format crowdin --id-interpolation-pattern \"[sha512:contenthash:base64:6]\" --out-file renderer/intl/locales/en-US.json",
     "compile:i18n": "formatjs compile-folder --ast --format crowdin renderer/intl/locales renderer/intl/compiled-locales",
     "i18n": "npm run extract:i18n && npm run compile:i18n",
-    "translate": "tsx scripts/openai-translator.ts"
+    "translate": "tsx scripts/openai-translator.ts",
+    "translate:missing": "tsx scripts/diff-translations.ts"
   },
   "license": "MPL-2.0",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepare": "husky install",
     "postinstall": "electron-builder install-app-deps",
     "release": "npm run i18n && nextron build --publish always",
-    "extract:i18n": "formatjs extract './renderer/{pages,components,sections,layouts,ui}/**/*.{js,ts,tsx}' --format crowdin --id-interpolation-pattern '[sha512:contenthash:base64:6]' --out-file renderer/intl/locales/en-US.json",
+    "extract:i18n": "formatjs extract renderer/{pages,components,sections,layouts,ui}/**/*.{js,ts,tsx} --format crowdin --id-interpolation-pattern \"[sha512:contenthash:base64:6]\" --out-file renderer/intl/locales/en-US.json",
     "compile:i18n": "formatjs compile-folder --ast --format crowdin renderer/intl/locales renderer/intl/compiled-locales",
     "i18n": "npm run extract:i18n && npm run compile:i18n",
     "translate": "tsx scripts/openai-translator.ts"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "compile:i18n": "formatjs compile-folder --ast --format crowdin renderer/intl/locales renderer/intl/compiled-locales",
     "i18n": "npm run extract:i18n && npm run compile:i18n",
     "translate": "tsx scripts/openai-translator.ts",
-    "translate:missing": "tsx scripts/diff-translations.ts"
+    "translate:diff": "tsx scripts/diff-translations.ts"
   },
   "license": "MPL-2.0",
   "dependencies": {

--- a/renderer/components/AccountSettings/AccountSettings.tsx
+++ b/renderer/components/AccountSettings/AccountSettings.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import { useState } from "react";
 import { defineMessages, useIntl } from "react-intl";
 
-import { DeleteAccountModal } from "@/components/DeleteAccountModal/DeleteAccountModal";
+import { RemoveAccountModal } from "@/components/RemoveAccountModal/RemoveAccountModal";
 import { trpcReact } from "@/providers/TRPCProvider";
 import { TextInput } from "@/ui/Forms/TextInput/TextInput";
 import { PillButton } from "@/ui/PillButton/PillButton";
@@ -23,8 +23,8 @@ const messages = defineMessages({
   saveChanges: {
     defaultMessage: "Save Changes",
   },
-  deleteAccount: {
-    defaultMessage: "Delete Account",
+  removeAccount: {
+    defaultMessage: "Remove Account",
   },
 });
 
@@ -70,9 +70,9 @@ export function AccountSettings({ accountName }: Props) {
   const hasValidName = newName.length > 0;
 
   const {
-    isOpen: isDeleteModalOpen,
-    onOpen: onDeleteModalOpen,
-    onClose: onDeleteModalClose,
+    isOpen: isRemoveModalOpen,
+    onOpen: onRemoveModalOpen,
+    onClose: onRemoveModalClose,
   } = useDisclosure();
 
   return (
@@ -102,20 +102,20 @@ export function AccountSettings({ accountName }: Props) {
           </PillButton>
           <PillButton
             isDisabled={isRenameLoading}
-            onClick={onDeleteModalOpen}
+            onClick={onRemoveModalOpen}
             variant="inverted"
             height="60px"
             px={8}
             border={0}
           >
-            {formatMessage(messages.deleteAccount)}
+            {formatMessage(messages.removeAccount)}
           </PillButton>
         </HStack>
       </VStack>
       {isSyncedData && accountData && (
-        <DeleteAccountModal
-          isOpen={isDeleteModalOpen}
-          onClose={onDeleteModalClose}
+        <RemoveAccountModal
+          isOpen={isRemoveModalOpen}
+          onClose={onRemoveModalClose}
           isSynced={isSyncedData.synced}
           account={accountData}
         />

--- a/renderer/components/DeleteAccountModal/DeleteAccountModal.tsx
+++ b/renderer/components/DeleteAccountModal/DeleteAccountModal.tsx
@@ -1,0 +1,253 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalFooter,
+  ModalBody,
+  Heading,
+  Text,
+  VStack,
+  Box,
+  Progress,
+  UnorderedList,
+  ListItem,
+} from "@chakra-ui/react";
+import { useRouter } from "next/router";
+import { useCallback, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { defineMessages, useIntl } from "react-intl";
+
+import { getTrpcVanillaClient, trpcReact } from "@/providers/TRPCProvider";
+import { TextInput } from "@/ui/Forms/TextInput/TextInput";
+import { PillButton } from "@/ui/PillButton/PillButton";
+import { formatOre } from "@/utils/ironUtils";
+
+const messages = defineMessages({
+  deleteAccount: {
+    defaultMessage: "Delete Account",
+  },
+  notSyncedWarning: {
+    defaultMessage:
+      "This account is not yet synced and may contain $IRON or other assets.",
+  },
+  hasBalanceWarning: {
+    defaultMessage: "This account currently holds the following assets:",
+  },
+  loseAssetsWarning: {
+    defaultMessage:
+      "If you delete this account without exporting it first, YOU WILL LOSE THESE ASSETS.",
+  },
+  loading: {
+    defaultMessage: "Loading...",
+  },
+  tryAgain: {
+    defaultMessage: "Try Again",
+  },
+  somethingWentWrong: {
+    defaultMessage: "Something went wrong, please try again.",
+  },
+  cancel: {
+    defaultMessage: "Cancel",
+  },
+  deleteAccountButton: {
+    defaultMessage: "Delete Account",
+  },
+  closeButton: {
+    defaultMessage: "Close",
+  },
+  areYouSure: {
+    defaultMessage: "Are you sure you want to delete the account?",
+  },
+  typeToDelete: {
+    defaultMessage: "Type ''{accountName}'' to delete",
+  },
+  textMustMatch: {
+    defaultMessage: "Text must match the account name ''{accountName}''",
+  },
+});
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  isSynced: boolean;
+  account: Awaited<
+    ReturnType<ReturnType<typeof getTrpcVanillaClient>["getAccount"]["query"]>
+  >;
+};
+
+export function DeleteAccountModal({
+  isOpen,
+  onClose,
+  account,
+  isSynced,
+}: Props) {
+  const router = useRouter();
+
+  const {
+    mutate: deleteAccount,
+    isIdle,
+    isLoading,
+    isError,
+    isSuccess,
+    reset,
+  } = trpcReact.deleteAccount.useMutation({
+    onSuccess: () => {
+      router.replace("/accounts");
+    },
+  });
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset: resetForm,
+  } = useForm<{ name: string }>();
+
+  const { formatMessage } = useIntl();
+
+  const handleClose = useCallback(() => {
+    reset();
+    resetForm();
+    onClose();
+  }, [onClose, reset, resetForm]);
+
+  useEffect(() => {
+    if (isSuccess) {
+      reset();
+      resetForm();
+      handleClose();
+    }
+  }, [handleClose, isSuccess, reset, resetForm]);
+
+  const balances = [account.balances.iron, ...account.balances.custom].filter(
+    (b) => b.unconfirmed !== "0",
+  );
+  const hasBalance = balances.length > 0;
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose}>
+      <ModalOverlay />
+      <ModalContent maxW="100%" width="600px">
+        <ModalBody px={16} pt={16}>
+          {!isError && (
+            <>
+              <Heading fontSize="2xl" mb={4}>
+                {formatMessage(messages.deleteAccount)}
+              </Heading>
+
+              {!isSynced && (
+                <Text fontSize="md" mb={6}>
+                  {formatMessage(messages.notSyncedWarning)}
+                </Text>
+              )}
+
+              {isSynced && hasBalance && (
+                <>
+                  <Text fontSize="md" mb={6}>
+                    {formatMessage(messages.hasBalanceWarning)}
+                  </Text>
+                  <UnorderedList mb={6}>
+                    {balances.map((b) => (
+                      <ListItem key={b.assetId}>{`${formatOre(b.unconfirmed)} ${
+                        b.asset.name
+                      }`}</ListItem>
+                    ))}
+                  </UnorderedList>
+                </>
+              )}
+
+              {(!isSynced || hasBalance) && (
+                <Text fontSize="md" mb={6}>
+                  {formatMessage(messages.loseAssetsWarning)}
+                </Text>
+              )}
+
+              <Text fontSize="md" mb={6}>
+                {formatMessage(messages.areYouSure, {
+                  accountName: account.name,
+                })}
+              </Text>
+
+              {isError && (
+                <Text fontSize="md">
+                  {formatMessage(messages.somethingWentWrong)}
+                </Text>
+              )}
+
+              {isLoading ? (
+                <Box py={8}>
+                  <Progress size="sm" isIndeterminate />
+                </Box>
+              ) : (
+                <VStack gap={4} alignItems="stretch">
+                  <TextInput
+                    {...register("name", { pattern: new RegExp(account.name) })}
+                    label={formatMessage(messages.typeToDelete, {
+                      accountName: account.name,
+                    })}
+                    error={
+                      errors.name &&
+                      formatMessage(messages.textMustMatch, {
+                        accountName: account.name,
+                      })
+                    }
+                  />
+                </VStack>
+              )}
+            </>
+          )}
+        </ModalBody>
+
+        <ModalFooter display="flex" gap={2} px={16} py={8}>
+          {(isIdle || isLoading) && (
+            <>
+              <PillButton
+                size="sm"
+                isDisabled={isLoading}
+                onClick={handleClose}
+                variant="inverted"
+                border={0}
+              >
+                {formatMessage(messages.cancel)}
+              </PillButton>
+              <PillButton
+                size="sm"
+                isDisabled={isLoading}
+                onClick={() => {
+                  handleSubmit(() => {
+                    deleteAccount({ account: account.name });
+                  })();
+                }}
+              >
+                {formatMessage(messages.deleteAccountButton)}
+              </PillButton>
+            </>
+          )}
+          {isError && (
+            <>
+              <PillButton
+                size="sm"
+                isDisabled={isLoading}
+                onClick={onClose}
+                variant="inverted"
+                border={0}
+              >
+                {formatMessage(messages.closeButton)}
+              </PillButton>
+              <PillButton
+                size="sm"
+                isDisabled={isLoading}
+                onClick={() => {
+                  resetForm();
+                  reset();
+                }}
+              >
+                {formatMessage(messages.tryAgain)}
+              </PillButton>
+            </>
+          )}
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/renderer/components/DeleteAccountModal/DeleteAccountModal.tsx
+++ b/renderer/components/DeleteAccountModal/DeleteAccountModal.tsx
@@ -181,7 +181,9 @@ export function DeleteAccountModal({
               ) : (
                 <VStack gap={4} alignItems="stretch">
                   <TextInput
-                    {...register("name", { pattern: new RegExp(account.name) })}
+                    {...register("name", {
+                      validate: (input) => input === account.name,
+                    })}
                     label={formatMessage(messages.typeToDelete, {
                       accountName: account.name,
                     })}

--- a/renderer/components/RemoveAccountModal/RemoveAccountModal.tsx
+++ b/renderer/components/RemoveAccountModal/RemoveAccountModal.tsx
@@ -18,6 +18,7 @@ import { useForm } from "react-hook-form";
 import { defineMessages, useIntl } from "react-intl";
 
 import { getTrpcVanillaClient, trpcReact } from "@/providers/TRPCProvider";
+import { COLORS } from "@/ui/colors";
 import { TextInput } from "@/ui/Forms/TextInput/TextInput";
 import { PillButton } from "@/ui/PillButton/PillButton";
 import { hexToUTF16String } from "@/utils/hexToUTF16String";
@@ -27,19 +28,12 @@ const messages = defineMessages({
   removeAccount: {
     defaultMessage: "Remove Account",
   },
-  notSyncedWarning: {
-    defaultMessage:
-      "This account is not yet synced and may contain $IRON or other assets.",
-  },
   hasBalanceWarning: {
     defaultMessage: "It currently holds:",
   },
   loseAccessWarning: {
     defaultMessage:
       "If you remove this account without exporting it first, YOU WILL LOSE ACCESS TO IT.",
-  },
-  loading: {
-    defaultMessage: "Loading...",
   },
   tryAgain: {
     defaultMessage: "Try Again",
@@ -58,6 +52,10 @@ const messages = defineMessages({
   },
   areYouSure: {
     defaultMessage: "Are you sure you want to remove this account?",
+  },
+  areYouSureSyncing: {
+    defaultMessage:
+      "Your balance may not be fully updated during this syncing process.",
   },
   typeToRemove: {
     defaultMessage: "Type ''{accountName}'' to remove",
@@ -136,15 +134,33 @@ export function RemoveAccountModal({
                 {formatMessage(messages.removeAccount)}
               </Heading>
 
-              <Text fontSize="md" mb={6}>
-                {formatMessage(messages.areYouSure, {
-                  accountName: account.name,
-                })}{" "}
-                {isSynced &&
-                  hasBalance &&
-                  formatMessage(messages.hasBalanceWarning)}{" "}
-                {!isSynced && formatMessage(messages.notSyncedWarning)}
-              </Text>
+              {!isSynced && (
+                <Box
+                  mb={8}
+                  borderRadius="4px"
+                  bg={COLORS.YELLOW_LIGHT}
+                  color="#7E7400"
+                  _dark={{
+                    bg: COLORS.DARK_MODE.YELLOW_DARK,
+                    color: COLORS.DARK_MODE.YELLOW_LIGHT,
+                  }}
+                  fontSize="sm"
+                  textAlign="center"
+                  lineHeight="160%"
+                  py={1}
+                  px={6}
+                >
+                  {formatMessage(messages.areYouSure)}{" "}
+                  {formatMessage(messages.areYouSureSyncing)}
+                </Box>
+              )}
+
+              {isSynced && (
+                <Text fontSize="md" mb={6}>
+                  {formatMessage(messages.areYouSure)}{" "}
+                  {hasBalance && formatMessage(messages.hasBalanceWarning)}
+                </Text>
+              )}
 
               {isSynced && hasBalance && (
                 <UnorderedList mb={6} pl={1}>

--- a/renderer/components/RemoveAccountModal/RemoveAccountModal.tsx
+++ b/renderer/components/RemoveAccountModal/RemoveAccountModal.tsx
@@ -20,22 +20,23 @@ import { defineMessages, useIntl } from "react-intl";
 import { getTrpcVanillaClient, trpcReact } from "@/providers/TRPCProvider";
 import { TextInput } from "@/ui/Forms/TextInput/TextInput";
 import { PillButton } from "@/ui/PillButton/PillButton";
+import { hexToUTF16String } from "@/utils/hexToUTF16String";
 import { formatOre } from "@/utils/ironUtils";
 
 const messages = defineMessages({
-  deleteAccount: {
-    defaultMessage: "Delete Account",
+  removeAccount: {
+    defaultMessage: "Remove Account",
   },
   notSyncedWarning: {
     defaultMessage:
       "This account is not yet synced and may contain $IRON or other assets.",
   },
   hasBalanceWarning: {
-    defaultMessage: "This account currently holds the following assets:",
+    defaultMessage: "It currently holds:",
   },
-  loseAssetsWarning: {
+  loseAccessWarning: {
     defaultMessage:
-      "If you delete this account without exporting it first, YOU WILL LOSE THESE ASSETS.",
+      "If you remove this account without exporting it first, YOU WILL LOSE ACCESS TO IT.",
   },
   loading: {
     defaultMessage: "Loading...",
@@ -49,17 +50,17 @@ const messages = defineMessages({
   cancel: {
     defaultMessage: "Cancel",
   },
-  deleteAccountButton: {
-    defaultMessage: "Delete Account",
+  removeAccountButton: {
+    defaultMessage: "Remove Account",
   },
   closeButton: {
     defaultMessage: "Close",
   },
   areYouSure: {
-    defaultMessage: "Are you sure you want to delete the account?",
+    defaultMessage: "Are you sure you want to remove this account?",
   },
-  typeToDelete: {
-    defaultMessage: "Type ''{accountName}'' to delete",
+  typeToRemove: {
+    defaultMessage: "Type ''{accountName}'' to remove",
   },
   textMustMatch: {
     defaultMessage: "Text must match the account name ''{accountName}''",
@@ -75,7 +76,7 @@ type Props = {
   >;
 };
 
-export function DeleteAccountModal({
+export function RemoveAccountModal({
   isOpen,
   onClose,
   account,
@@ -128,44 +129,35 @@ export function DeleteAccountModal({
     <Modal isOpen={isOpen} onClose={handleClose}>
       <ModalOverlay />
       <ModalContent maxW="100%" width="600px">
-        <ModalBody px={16} pt={16}>
+        <ModalBody px={16} pt={16} pb={0}>
           {!isError && (
             <>
-              <Heading fontSize="2xl" mb={4}>
-                {formatMessage(messages.deleteAccount)}
+              <Heading fontSize="28px" lineHeight="160%" mb={4}>
+                {formatMessage(messages.removeAccount)}
               </Heading>
-
-              {!isSynced && (
-                <Text fontSize="md" mb={6}>
-                  {formatMessage(messages.notSyncedWarning)}
-                </Text>
-              )}
-
-              {isSynced && hasBalance && (
-                <>
-                  <Text fontSize="md" mb={6}>
-                    {formatMessage(messages.hasBalanceWarning)}
-                  </Text>
-                  <UnorderedList mb={6}>
-                    {balances.map((b) => (
-                      <ListItem key={b.assetId}>{`${formatOre(b.unconfirmed)} ${
-                        b.asset.name
-                      }`}</ListItem>
-                    ))}
-                  </UnorderedList>
-                </>
-              )}
-
-              {(!isSynced || hasBalance) && (
-                <Text fontSize="md" mb={6}>
-                  {formatMessage(messages.loseAssetsWarning)}
-                </Text>
-              )}
 
               <Text fontSize="md" mb={6}>
                 {formatMessage(messages.areYouSure, {
                   accountName: account.name,
-                })}
+                })}{" "}
+                {isSynced &&
+                  hasBalance &&
+                  formatMessage(messages.hasBalanceWarning)}{" "}
+                {!isSynced && formatMessage(messages.notSyncedWarning)}
+              </Text>
+
+              {isSynced && hasBalance && (
+                <UnorderedList mb={6} pl={1}>
+                  {balances.map((b) => (
+                    <ListItem key={b.assetId}>{`${formatOre(
+                      b.unconfirmed,
+                    )} ${hexToUTF16String(b.asset.name)}`}</ListItem>
+                  ))}
+                </UnorderedList>
+              )}
+
+              <Text fontSize="md" mb={8}>
+                {formatMessage(messages.loseAccessWarning)}
               </Text>
 
               {isError && (
@@ -184,7 +176,7 @@ export function DeleteAccountModal({
                     {...register("name", {
                       validate: (input) => input === account.name,
                     })}
-                    label={formatMessage(messages.typeToDelete, {
+                    label={formatMessage(messages.typeToRemove, {
                       accountName: account.name,
                     })}
                     error={
@@ -221,7 +213,7 @@ export function DeleteAccountModal({
                   })();
                 }}
               >
-                {formatMessage(messages.deleteAccountButton)}
+                {formatMessage(messages.removeAccountButton)}
               </PillButton>
             </>
           )}

--- a/renderer/intl/locales/en-US.json
+++ b/renderer/intl/locales/en-US.json
@@ -24,6 +24,9 @@
   "/zn2B0": {
     "message": "View only accounts cannot initiate transactions"
   },
+  "0rIM5R": {
+    "message": "Remove Account"
+  },
   "21ueTy": {
     "message": "Public Address"
   },
@@ -104,9 +107,6 @@
   },
   "6P/bTL": {
     "message": "Connection Type"
-  },
-  "6hS0se": {
-    "message": "Are you sure you want to delete the account?"
   },
   "6q3tCn": {
     "message": "Connecting"
@@ -222,8 +222,14 @@
   "HkADqs": {
     "message": "Fee ($IRON)"
   },
+  "HtgUU8": {
+    "message": "Type ''{accountName}'' to remove"
+  },
   "JJNc3c": {
     "message": "Previous"
+  },
+  "JM4YI+": {
+    "message": "Are you sure you want to remove this account?"
   },
   "Jjpq7w": {
     "message": "Block Sequence"
@@ -266,9 +272,6 @@
   },
   "MFUhla": {
     "message": "Highest to lowest balance"
-  },
-  "MlzVS6": {
-    "message": "If you delete this account without exporting it first, YOU WILL LOSE THESE ASSETS."
   },
   "N0KGQj": {
     "message": "Block Graffiti"
@@ -314,9 +317,6 @@
   },
   "Qu9LpU": {
     "message": "The selected account is syncing. Your balance may be inaccurate and sending transactions will be disabled until the sync is complete."
-  },
-  "R2OqnW": {
-    "message": "Delete Account"
   },
   "RIUFf+": {
     "message": "Ukrainian"
@@ -459,6 +459,9 @@
   "dM+p3/": {
     "message": "From"
   },
+  "dTSUUK": {
+    "message": "If you remove this account without exporting it first, YOU WILL LOSE ACCESS TO IT."
+  },
   "e6Ph5+": {
     "message": "Address"
   },
@@ -525,9 +528,6 @@
   "j2AFTQ": {
     "message": "Node Status"
   },
-  "jURX0R": {
-    "message": "Type ''{accountName}'' to delete"
-  },
   "jc6sBv": {
     "message": "Contact updated"
   },
@@ -545,9 +545,6 @@
   },
   "kTt/ND": {
     "message": "Russian"
-  },
-  "kYXW+e": {
-    "message": "This account currently holds the following assets:"
   },
   "lu5YPq": {
     "message": "unknown asset"
@@ -632,6 +629,9 @@
   },
   "vV69eP": {
     "message": "Downloading a snapshot is the fastest way to sync with the network."
+  },
+  "vaP4MI": {
+    "message": "It currently holds:"
   },
   "wGpbja": {
     "message": "Add Contact Error"

--- a/renderer/intl/locales/en-US.json
+++ b/renderer/intl/locales/en-US.json
@@ -105,6 +105,9 @@
   "6P/bTL": {
     "message": "Connection Type"
   },
+  "6hS0se": {
+    "message": "Are you sure you want to delete the account?"
+  },
   "6q3tCn": {
     "message": "Connecting"
   },
@@ -264,14 +267,14 @@
   "MFUhla": {
     "message": "Highest to lowest balance"
   },
+  "MlzVS6": {
+    "message": "If you delete this account without exporting it first, YOU WILL LOSE THESE ASSETS."
+  },
   "N0KGQj": {
     "message": "Block Graffiti"
   },
   "N0bVvU": {
     "message": "Error copied to clipboard"
-  },
-  "NDtjP8": {
-    "message": "Are you sure? You'll have to re-import this account if you want to use it again."
   },
   "NX/nQR": {
     "message": "Changing node settings can optimize performance, improve connectivity, enhance security, and manage resources effectively."
@@ -516,8 +519,14 @@
   "is+QTN": {
     "message": "Contact Settings"
   },
+  "j1Eelr": {
+    "message": "This account is not yet synced and may contain $IRON or other assets."
+  },
   "j2AFTQ": {
     "message": "Node Status"
+  },
+  "jURX0R": {
+    "message": "Type ''{accountName}'' to delete"
   },
   "jc6sBv": {
     "message": "Contact updated"
@@ -536,6 +545,9 @@
   },
   "kTt/ND": {
     "message": "Russian"
+  },
+  "kYXW+e": {
+    "message": "This account currently holds the following assets:"
   },
   "lu5YPq": {
     "message": "unknown asset"
@@ -662,5 +674,8 @@
   },
   "zR2zr+": {
     "message": "Address copied to clipboard"
+  },
+  "zl76y/": {
+    "message": "Text must match the account name ''{accountName}''"
   }
 }

--- a/renderer/intl/locales/en-US.json
+++ b/renderer/intl/locales/en-US.json
@@ -273,6 +273,9 @@
   "MFUhla": {
     "message": "Highest to lowest balance"
   },
+  "MFXvHT": {
+    "message": "Your balance may not be fully updated during this syncing process."
+  },
   "N0KGQj": {
     "message": "Block Graffiti"
   },
@@ -521,9 +524,6 @@
   },
   "is+QTN": {
     "message": "Contact Settings"
-  },
-  "j1Eelr": {
-    "message": "This account is not yet synced and may contain $IRON or other assets."
   },
   "j2AFTQ": {
     "message": "Node Status"

--- a/renderer/intl/locales/es-MX.json
+++ b/renderer/intl/locales/es-MX.json
@@ -31,6 +31,10 @@
     "message": "Las cuentas de solo lectura no pueden iniciar transacciones",
     "description": "View only accounts cannot initiate transactions"
   },
+  "0rIM5R": {
+    "message": "Eliminar Cuenta",
+    "description": "Remove Account"
+  },
   "21ueTy": {
     "message": "Dirección Pública",
     "description": "Public Address"
@@ -291,9 +295,17 @@
     "message": "Tarifa ($IRON)",
     "description": "Fee ($IRON)"
   },
+  "HtgUU8": {
+    "message": "Escriba ''{accountName}'' para eliminar",
+    "description": "Type ''{accountName}'' to remove"
+  },
   "JJNc3c": {
     "message": "Anterior",
     "description": "Previous"
+  },
+  "JM4YI+": {
+    "message": "¿Estás seguro de que quieres eliminar esta cuenta?",
+    "description": "Are you sure you want to remove this account?"
   },
   "Jjpq7w": {
     "message": "Secuencia de bloques",
@@ -351,6 +363,10 @@
     "message": "Mayor a menor saldo",
     "description": "Highest to lowest balance"
   },
+  "MFXvHT": {
+    "message": "Es posible que su saldo no se actualice completamente durante este proceso de sincronización",
+    "description": "Your balance may not be fully updated during this syncing process."
+  },
   "N0KGQj": {
     "message": "Graffiti de bloque",
     "description": "Block Graffiti"
@@ -358,10 +374,6 @@
   "N0bVvU": {
     "message": "Error copiado al portapapeles",
     "description": "Error copied to clipboard"
-  },
-  "NDtjP8": {
-    "message": "¿Estás seguro? Tendrás que volver a importar esta cuenta si quieres usarla de nuevo.",
-    "description": "Are you sure? You'll have to re-import this account if you want to use it again."
   },
   "NX/nQR": {
     "message": "Cambiar la configuración del nodo puede optimizar el rendimiento, mejorar la conectividad, mejorar la seguridad y gestionar eficientemente los recursos.",
@@ -414,10 +426,6 @@
   "Qu9LpU": {
     "message": "La cuenta seleccionada se está sincronizando. Su saldo puede no ser exacto y el envío de transacciones estará deshabilitado hasta que se complete la sincronización.",
     "description": "The selected account is syncing. Your balance may be inaccurate and sending transactions will be disabled until the sync is complete."
-  },
-  "R2OqnW": {
-    "message": "Eliminar cuenta",
-    "description": "Delete Account"
   },
   "RIUFf+": {
     "message": "Ucraniano",
@@ -606,6 +614,10 @@
   "dM+p3/": {
     "message": "De",
     "description": "From"
+  },
+  "dTSUUK": {
+    "message": "Si eliminas esta cuenta sin exportarla primero, PERDERÁS EL ACCESO A ELLA.",
+    "description": "If you remove this account without exporting it first, YOU WILL LOSE ACCESS TO IT."
   },
   "e6Ph5+": {
     "message": "Dirección",
@@ -827,6 +839,10 @@
     "message": "Descargar una instantánea es la forma más rápida de sincronizar con la red.",
     "description": "Downloading a snapshot is the fastest way to sync with the network."
   },
+  "vaP4MI": {
+    "message": "La cuenta actualmente tiene:",
+    "description": "It currently holds:"
+  },
   "wGpbja": {
     "message": "Error al agregar contacto",
     "description": "Add Contact Error"
@@ -882,5 +898,9 @@
   "zR2zr+": {
     "message": "Dirección copiada al portapapeles",
     "description": "Address copied to clipboard"
+  },
+  "zl76y/": {
+    "message": "El texto debe coincidir con el nombre de la cuenta ''{accountName}''",
+    "description": "Text must match the account name ''{accountName}''"
   }
 }

--- a/renderer/intl/locales/ru-RU.json
+++ b/renderer/intl/locales/ru-RU.json
@@ -31,6 +31,10 @@
     "message": "Учетные записи только для просмотра не могут инициировать транзакции",
     "description": "View only accounts cannot initiate transactions"
   },
+  "0rIM5R": {
+    "message": "Удалить аккаунт",
+    "description": "Remove Account"
+  },
   "21ueTy": {
     "message": "Публичный адрес",
     "description": "Public Address"
@@ -291,9 +295,17 @@
     "message": "Комиссия ($IRON)",
     "description": "Fee ($IRON)"
   },
+  "HtgUU8": {
+    "message": "Введите ''{accountName}'' для удаления",
+    "description": "Type ''{accountName}'' to remove"
+  },
   "JJNc3c": {
     "message": "Предыдущее",
     "description": "Previous"
+  },
+  "JM4YI+": {
+    "message": "Вы уверены, что хотите удалить этот аккаунт?",
+    "description": "Are you sure you want to remove this account?"
   },
   "Jjpq7w": {
     "message": "Последовательность блоков",
@@ -351,6 +363,10 @@
     "message": "От наибольшего к наименьшему балансу",
     "description": "Highest to lowest balance"
   },
+  "MFXvHT": {
+    "message": "Ваш баланс может не быть полностью обновлен во время этого процесса синхронизации",
+    "description": "Your balance may not be fully updated during this syncing process."
+  },
   "N0KGQj": {
     "message": "Граффити блока",
     "description": "Block Graffiti"
@@ -358,10 +374,6 @@
   "N0bVvU": {
     "message": "Ошибка скопирована в буфер обмена",
     "description": "Error copied to clipboard"
-  },
-  "NDtjP8": {
-    "message": "Вы уверены? Вам придется снова импортировать этот аккаунт, если вы захотите его использовать снова.",
-    "description": "Are you sure? You'll have to re-import this account if you want to use it again."
   },
   "NX/nQR": {
     "message": "Изменение настроек узла может оптимизировать производительность, улучшить подключение, повысить безопасность и эффективно управлять ресурсами.",
@@ -414,10 +426,6 @@
   "Qu9LpU": {
     "message": "Выбранный аккаунт синхронизируется. Ваш баланс может быть неточным и отправка транзакций будет отключена до окончания синхронизации.",
     "description": "The selected account is syncing. Your balance may be inaccurate and sending transactions will be disabled until the sync is complete."
-  },
-  "R2OqnW": {
-    "message": "Удалить аккаунт",
-    "description": "Delete Account"
   },
   "RIUFf+": {
     "message": "Украинский",
@@ -606,6 +614,10 @@
   "dM+p3/": {
     "message": "От",
     "description": "From"
+  },
+  "dTSUUK": {
+    "message": "Если вы удалите этот аккаунт, не экспортировав его сначала, ВЫ ПОТЕРЯЕТЕ ДОСТУП К НЕМУ.",
+    "description": "If you remove this account without exporting it first, YOU WILL LOSE ACCESS TO IT."
   },
   "e6Ph5+": {
     "message": "Адрес",
@@ -827,6 +839,10 @@
     "message": "Загрузка снимка - самый быстрый способ синхронизироваться с сетью.",
     "description": "Downloading a snapshot is the fastest way to sync with the network."
   },
+  "vaP4MI": {
+    "message": "На счету в настоящее время есть:",
+    "description": "It currently holds:"
+  },
   "wGpbja": {
     "message": "Ошибка добавления контакта",
     "description": "Add Contact Error"
@@ -882,5 +898,9 @@
   "zR2zr+": {
     "message": "Адрес скопирован в буфер обмена",
     "description": "Address copied to clipboard"
+  },
+  "zl76y/": {
+    "message": "Текст должен соответствовать имени учетной записи ''{accountName}''",
+    "description": "Text must match the account name ''{accountName}''"
   }
 }

--- a/renderer/intl/locales/uk-UA.json
+++ b/renderer/intl/locales/uk-UA.json
@@ -31,6 +31,10 @@
     "message": "Облікові записи тільки для перегляду не можуть ініціювати транзакції",
     "description": "View only accounts cannot initiate transactions"
   },
+  "0rIM5R": {
+    "message": "Видалити аккаунт",
+    "description": "Remove Account"
+  },
   "21ueTy": {
     "message": "Публічна адреса",
     "description": "Public Address"
@@ -291,9 +295,17 @@
     "message": "Комісія ($IRON)",
     "description": "Fee ($IRON)"
   },
+  "HtgUU8": {
+    "message": "Введіть ''{accountName}'' щоб видалити",
+    "description": "Type ''{accountName}'' to remove"
+  },
   "JJNc3c": {
     "message": "Попередній",
     "description": "Previous"
+  },
+  "JM4YI+": {
+    "message": "Ви впевнені, що хочете видалити цей обліковий запис?",
+    "description": "Are you sure you want to remove this account?"
   },
   "Jjpq7w": {
     "message": "Послідовність блоків",
@@ -351,6 +363,10 @@
     "message": "Від найвищого до найнижчого балансу",
     "description": "Highest to lowest balance"
   },
+  "MFXvHT": {
+    "message": "Ваш баланс може не бути повністю оновлений під час цього процесу синхронізації",
+    "description": "Your balance may not be fully updated during this syncing process."
+  },
   "N0KGQj": {
     "message": "Графіті блоків",
     "description": "Block Graffiti"
@@ -358,10 +374,6 @@
   "N0bVvU": {
     "message": "Помилка скопійована в буфер обміну",
     "description": "Error copied to clipboard"
-  },
-  "NDtjP8": {
-    "message": "Ви впевнені? Вам доведеться знову імпортувати цей обліковий запис, якщо ви знову захочете його використовувати.",
-    "description": "Are you sure? You'll have to re-import this account if you want to use it again."
   },
   "NX/nQR": {
     "message": "Зміна налаштувань вузла може оптимізувати продуктивність, покращити з'єднання, посилити безпеку та ефективно керувати ресурсами.",
@@ -414,10 +426,6 @@
   "Qu9LpU": {
     "message": "Обраний обліковий запис синхронізується. Ваш баланс може бути неточним, а відправлення транзакцій буде відключено до завершення синхронізації.",
     "description": "The selected account is syncing. Your balance may be inaccurate and sending transactions will be disabled until the sync is complete."
-  },
-  "R2OqnW": {
-    "message": "Видалити обліковий запис",
-    "description": "Delete Account"
   },
   "RIUFf+": {
     "message": "Українська",
@@ -606,6 +614,10 @@
   "dM+p3/": {
     "message": "Від",
     "description": "From"
+  },
+  "dTSUUK": {
+    "message": "Якщо ви видалите цей обліковий запис без його попереднього експорту, ВИ ВТРАТИТЕ ДОСТУП ДО НЬОГО.",
+    "description": "If you remove this account without exporting it first, YOU WILL LOSE ACCESS TO IT."
   },
   "e6Ph5+": {
     "message": "Адреса",
@@ -827,6 +839,10 @@
     "message": "Завантаження знімку є найшвидшим способом синхронізації з мережею.",
     "description": "Downloading a snapshot is the fastest way to sync with the network."
   },
+  "vaP4MI": {
+    "message": "На рахунку зараз є:",
+    "description": "It currently holds:"
+  },
   "wGpbja": {
     "message": "Помилка при додаванні контакту",
     "description": "Add Contact Error"
@@ -882,5 +898,9 @@
   "zR2zr+": {
     "message": "Адреса скопійована в буфер обміну",
     "description": "Address copied to clipboard"
+  },
+  "zl76y/": {
+    "message": "Текст повинен відповідати назві облікового запису ''{accountName}''",
+    "description": "Text must match the account name ''{accountName}''"
   }
 }

--- a/renderer/intl/locales/zh-CN.json
+++ b/renderer/intl/locales/zh-CN.json
@@ -31,6 +31,10 @@
     "message": "只读账户不能发起交易",
     "description": "View only accounts cannot initiate transactions"
   },
+  "0rIM5R": {
+    "message": "删除帐户",
+    "description": "Remove Account"
+  },
   "21ueTy": {
     "message": "公共地址",
     "description": "Public Address"
@@ -291,9 +295,17 @@
     "message": "手续费（$IRON）",
     "description": "Fee ($IRON)"
   },
+  "HtgUU8": {
+    "message": "输入''{accountName}''以移除",
+    "description": "Type ''{accountName}'' to remove"
+  },
   "JJNc3c": {
     "message": "前一个",
     "description": "Previous"
+  },
+  "JM4YI+": {
+    "message": "是否确实要删除此帐户",
+    "description": "Are you sure you want to remove this account?"
   },
   "Jjpq7w": {
     "message": "块序列",
@@ -351,6 +363,10 @@
     "message": "从高到低的余额",
     "description": "Highest to lowest balance"
   },
+  "MFXvHT": {
+    "message": "在此同步过程中，您的余额可能无法完全更新",
+    "description": "Your balance may not be fully updated during this syncing process."
+  },
   "N0KGQj": {
     "message": "区块涂鸦",
     "description": "Block Graffiti"
@@ -358,10 +374,6 @@
   "N0bVvU": {
     "message": "错误已复制到剪贴板",
     "description": "Error copied to clipboard"
-  },
-  "NDtjP8": {
-    "message": "你确定吗？如果你想再次使用它，你将必须重新导入这个账户。",
-    "description": "Are you sure? You'll have to re-import this account if you want to use it again."
   },
   "NX/nQR": {
     "message": "更改节点设置可以优化性能，提高连通性，增强安全性，并有效管理资源。",
@@ -414,10 +426,6 @@
   "Qu9LpU": {
     "message": "所选账户正在同步。您的余额可能不准确，直到同步完成，发送交易将被禁用。",
     "description": "The selected account is syncing. Your balance may be inaccurate and sending transactions will be disabled until the sync is complete."
-  },
-  "R2OqnW": {
-    "message": "删除账户",
-    "description": "Delete Account"
   },
   "RIUFf+": {
     "message": "乌克兰语",
@@ -606,6 +614,10 @@
   "dM+p3/": {
     "message": "从",
     "description": "From"
+  },
+  "dTSUUK": {
+    "message": "如果您在首先导出此帐户之前将其删除，您将无法再访问它。",
+    "description": "If you remove this account without exporting it first, YOU WILL LOSE ACCESS TO IT."
   },
   "e6Ph5+": {
     "message": "地址",
@@ -827,6 +839,10 @@
     "message": "下载快照是与网络同步的最快方式。",
     "description": "Downloading a snapshot is the fastest way to sync with the network."
   },
+  "vaP4MI": {
+    "message": "该帐户当前具有：",
+    "description": "It currently holds:"
+  },
   "wGpbja": {
     "message": "添加联系人错误",
     "description": "Add Contact Error"
@@ -882,5 +898,9 @@
   "zR2zr+": {
     "message": "地址已复制到剪贴板",
     "description": "Address copied to clipboard"
+  },
+  "zl76y/": {
+    "message": "文本必须与帐户名称''{accountName}''匹配",
+    "description": "Text must match the account name ''{accountName}''"
   }
 }

--- a/renderer/ui/theme/styleConfigs/modal.ts
+++ b/renderer/ui/theme/styleConfigs/modal.ts
@@ -8,10 +8,9 @@ const { definePartsStyle, defineMultiStyleConfig } =
 
 const baseStyle = definePartsStyle({
   dialog: {
-    borderWidth: "1px",
+    borderRadius: "4px",
     _dark: {
       bg: COLORS.DARK_MODE.BG,
-      borderColor: COLORS.DARK_MODE.GRAY_MEDIUM,
     },
   },
 });

--- a/scripts/diff-translations.ts
+++ b/scripts/diff-translations.ts
@@ -1,0 +1,51 @@
+import fs from "fs/promises";
+import path from "path";
+
+import { LOCALES } from "../renderer/intl/intl-constants";
+import english from "../renderer/intl/locales/en-US.json";
+
+// Removes old entries from locale files and logs new entries with the text
+// from the en-US locale. Run with this:
+//
+// npm run translate:missing
+async function main() {
+  const englishKeys = new Set(Object.keys(english));
+
+  for (const locale of LOCALES) {
+    if (locale === "en-US") {
+      continue;
+    }
+    const filepath = path.join(
+      __dirname,
+      `../renderer/intl/locales/${locale}.json`,
+    );
+    const data = JSON.parse(await fs.readFile(filepath, { encoding: "utf8" }));
+    const dataKeys = new Set(Object.keys(data));
+
+    // Delete keys that are no longer used
+    for (const key of Object.keys(data)) {
+      if (!englishKeys.has(key)) {
+        delete data[key];
+      }
+    }
+
+    await fs.writeFile(filepath, JSON.stringify(data, null, 2), {
+      encoding: "utf8",
+    });
+
+    // Log to be translated
+    const missing: Array<string> = [];
+    for (const [key, value] of Object.entries(english)) {
+      if (!dataKeys.has(key)) {
+        missing.push(`${key}: ${value.message}`);
+      }
+    }
+
+    if (missing.length) {
+      console.log(`\n${locale}`);
+      console.log(missing.join("\n"));
+    }
+  }
+}
+
+main();

--- a/scripts/diff-translations.ts
+++ b/scripts/diff-translations.ts
@@ -33,7 +33,7 @@ async function main() {
       encoding: "utf8",
     });
 
-    // Log to be translated
+    // Log keys to be translated
     const missing: Array<string> = [];
     for (const [key, value] of Object.entries(english)) {
       if (!dataKeys.has(key)) {


### PR DESCRIPTION
Adds a RemoveAccountModal to replace the default alert styling.

## Account has assets

<img width="916" alt="Screenshot 2024-01-17 185031" src="https://github.com/iron-fish/ironfish-node-app/assets/767083/f1ca7ab6-1e89-49dc-a6c0-b276d5e7917c">

## Account is syncing

<img width="922" alt="Screenshot 2024-01-18 112205" src="https://github.com/iron-fish/ironfish-node-app/assets/767083/020c9584-3a07-439a-8e0e-18d559867663">

## Account is synced and has no assets

<img width="916" alt="Screenshot 2024-01-17 185050" src="https://github.com/iron-fish/ironfish-node-app/assets/767083/da9a2d1b-0b38-42a7-8ca2-cd4f8207bad2">

## Entered account name incorrectly
<img width="916" alt="Screenshot 2024-01-17 185714" src="https://github.com/iron-fish/ironfish-node-app/assets/767083/3ed0f130-db95-4a17-94e8-35d84656c237">


Fixes IFL-2075