### PR TITLE
Use transparent background for windows WindowControl buttons

### DIFF
--- a/main/background.ts
+++ b/main/background.ts
@@ -55,12 +55,12 @@ async function createThemeChangeHandler() {
       if (nativeTheme.shouldUseDarkColors) {
         // setTitleBarOverlay is undefined on non-Windows platforms
         mw.setTitleBarOverlay?.({
-          color: "#10101000",
+          color: "#10101022",
           symbolColor: "#ffffff",
         });
       } else {
         mw.setTitleBarOverlay?.({
-          color: "#ffffff00",
+          color: "#ffffff22",
           symbolColor: "#101010",
         });
       }

--- a/main/background.ts
+++ b/main/background.ts
@@ -55,12 +55,12 @@ async function createThemeChangeHandler() {
       if (nativeTheme.shouldUseDarkColors) {
         // setTitleBarOverlay is undefined on non-Windows platforms
         mw.setTitleBarOverlay?.({
-          color: "#101010",
+          color: "#10101000",
           symbolColor: "#ffffff",
         });
       } else {
         mw.setTitleBarOverlay?.({
-          color: "#ffffff",
+          color: "#ffffff00",
           symbolColor: "#101010",
         });
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepare": "husky install",
     "postinstall": "electron-builder install-app-deps",
     "release": "npm run i18n && nextron build --publish always",
-    "extract:i18n": "formatjs extract './renderer/{pages,components,sections,layouts,ui}/**/*.{js,ts,tsx}' --format crowdin --id-interpolation-pattern '[sha512:contenthash:base64:6]' --out-file renderer/intl/locales/en-US.json",
+    "extract:i18n": "formatjs extract renderer/{pages,components,sections,layouts,ui}/**/*.{js,ts,tsx} --format crowdin --id-interpolation-pattern \"[sha512:contenthash:base64:6]\" --out-file renderer/intl/locales/en-US.json",
     "compile:i18n": "formatjs compile-folder --ast --format crowdin renderer/intl/locales renderer/intl/compiled-locales",
     "i18n": "npm run extract:i18n && npm run compile:i18n",
     "translate": "tsx scripts/openai-translator.ts"


### PR DESCRIPTION
I noticed that the window button background didn't match with the modal when the background changes color. We can make it transparent to improve the look a bit.

## Current

<img width="918" alt="Screenshot 2024-01-17 191529" src="https://github.com/iron-fish/ironfish-node-app/assets/767083/71ce63b8-d4d5-4b2a-aa64-c5284b655b6f">

## New

<img width="1182" alt="Screenshot 2024-01-17 110551" src="https://github.com/iron-fish/ironfish-node-app/assets/767083/9a75b843-f5e9-4c35-91fa-7ce3a87e1cb3">