### PR TITLE
Fix width on Onboarding Import page

### DIFF
--- a/renderer/layouts/OnboardingLayout.tsx
+++ b/renderer/layouts/OnboardingLayout.tsx
@@ -48,6 +48,7 @@ export function OnboardingLayout({ children }: { children: ReactNode }) {
           </Box>
         </Box>
         <VStack
+          alignItems="stretch"
           gap={0}
           bg="white"
           h="100%"
@@ -78,7 +79,7 @@ export function OnboardingLayout({ children }: { children: ReactNode }) {
             }}
             py={16}
           >
-            {children}
+            <Box flex={1}>{children}</Box>
           </Flex>
           <Flex
             borderTop="1px solid #DEDFE2"


### PR DESCRIPTION
The Import Account forms weren't stretched to the full width of the container.

Fixes IFL-2122