### PR TITLE
Add translations to ConfirmAccountStep component

### DIFF
--- a/renderer/components/OnboardingFlow/CreateAccount/ConfirmAccountStep.tsx
+++ b/renderer/components/OnboardingFlow/CreateAccount/ConfirmAccountStep.tsx
@@ -1,5 +1,6 @@
 import { Box, Heading, Text } from "@chakra-ui/react";
 import { useState, useMemo } from "react";
+import { defineMessages, useIntl } from "react-intl";
 
 import { BackButton } from "@/components/BackButton/BackButton";
 import { COLORS } from "@/ui/colors";
@@ -9,6 +10,21 @@ import {
 } from "@/ui/Forms/MnemonicPhrase/MnemonicPhrase";
 import { PillButton } from "@/ui/PillButton/PillButton";
 import { validateMnemonic } from "@/utils/mnemonic";
+
+const messages = defineMessages({
+  createAccount: {
+    defaultMessage: "Create Account",
+  },
+  confirmRecoveryPhrase: {
+    defaultMessage: "Confirm Your Recovery Phrase",
+  },
+  recoveryPhraseDescription: {
+    defaultMessage: "Please keep this phrase stored somewhere safe.",
+  },
+  continueButton: {
+    defaultMessage: "Continue",
+  },
+});
 
 export function ConfirmAccountStep({
   mnemonicPhrase,
@@ -22,6 +38,7 @@ export function ConfirmAccountStep({
   onBack: () => void;
   isLoading?: boolean;
 }) {
+  const { formatMessage } = useIntl();
   const [confirmValues, setConfirmValues] =
     useState<Array<string>>(EMPTY_PHRASE_ARRAY);
 
@@ -35,14 +52,14 @@ export function ConfirmAccountStep({
     <Box pointerEvents={isLoading ? "none" : undefined}>
       <BackButton onClick={onBack} />
       <Heading mt={4} mb={8}>
-        Create Account
+        {formatMessage(messages.createAccount)}
       </Heading>
 
       <Text fontSize="2xl" mb={1}>
-        Confirm Your Recovery Phrase
+        {formatMessage(messages.confirmRecoveryPhrase)}
       </Text>
       <Text color={COLORS.GRAY_MEDIUM} mb={4}>
-        Please keep this phrase stored somewhere safe.
+        {formatMessage(messages.recoveryPhraseDescription)}
       </Text>
       <MnemonicPhrase
         defaultVisible
@@ -54,7 +71,7 @@ export function ConfirmAccountStep({
         mb={8}
       />
       <PillButton isDisabled={isLoading || !isValid} onClick={onNextStep}>
-        Continue
+        {formatMessage(messages.continueButton)}
       </PillButton>
     </Box>
   );

--- a/renderer/intl/locales/en-US.json
+++ b/renderer/intl/locales/en-US.json
@@ -309,6 +309,9 @@
   "Pq25uf": {
     "message": "Reset Node"
   },
+  "Q/MbJP": {
+    "message": "Please keep this phrase stored somewhere safe."
+  },
   "QS9NTE": {
     "message": "Account name — A to Z"
   },
@@ -605,6 +608,9 @@
   },
   "rfxp5c": {
     "message": "Confirm & Send"
+  },
+  "rqrhXg": {
+    "message": "Confirm Your Recovery Phrase"
   },
   "tf+yHL": {
     "message": "Fast"

--- a/renderer/intl/locales/es-MX.json
+++ b/renderer/intl/locales/es-MX.json
@@ -411,6 +411,10 @@
     "message": "Resetear Nodo",
     "description": "Reset Node"
   },
+  "Q/MbJP": {
+    "message": "Por favor, guarda esta frase en un lugar seguro.",
+    "description": "Please keep this phrase stored somewhere safe."
+  },
   "QS9NTE": {
     "message": "Nombre de la cuenta — A a Z",
     "description": "Account name — A to Z"
@@ -806,6 +810,10 @@
   "rfxp5c": {
     "message": "Confirmar y enviar",
     "description": "Confirm & Send"
+  },
+  "rqrhXg": {
+    "message": "Confirma tu Frase de Recuperación",
+    "description": "Confirm Your Recovery Phrase"
   },
   "tf+yHL": {
     "message": "Rápido",

--- a/renderer/intl/locales/ru-RU.json
+++ b/renderer/intl/locales/ru-RU.json
@@ -411,6 +411,10 @@
     "message": "Сбросить Узел",
     "description": "Reset Node"
   },
+  "Q/MbJP": {
+    "message": "Пожалуйста, сохраните эту фразу в безопасном месте.",
+    "description": "Please keep this phrase stored somewhere safe."
+  },
   "QS9NTE": {
     "message": "Имя аккаунта от А до Я",
     "description": "Account name — A to Z"
@@ -806,6 +810,10 @@
   "rfxp5c": {
     "message": "Подтвердить и отправить",
     "description": "Confirm & Send"
+  },
+  "rqrhXg": {
+    "message": "Подтвердите вашу фразу восстановления",
+    "description": "Confirm Your Recovery Phrase"
   },
   "tf+yHL": {
     "message": "Быстро",

--- a/renderer/intl/locales/uk-UA.json
+++ b/renderer/intl/locales/uk-UA.json
@@ -411,6 +411,10 @@
     "message": "Скидання вузла",
     "description": "Reset Node"
   },
+  "Q/MbJP": {
+    "message": "Будь ласка, зберігайте цю фразу в безпечному місці.",
+    "description": "Please keep this phrase stored somewhere safe."
+  },
   "QS9NTE": {
     "message": "Назва облікового запису — від А до Я",
     "description": "Account name — A to Z"
@@ -806,6 +810,10 @@
   "rfxp5c": {
     "message": "Підтвердіть і надішліть",
     "description": "Confirm & Send"
+  },
+  "rqrhXg": {
+    "message": "Підтвердіть вашу фразу відновлення",
+    "description": "Confirm Your Recovery Phrase"
   },
   "tf+yHL": {
     "message": "Швидко",

--- a/renderer/intl/locales/zh-CN.json
+++ b/renderer/intl/locales/zh-CN.json
@@ -411,6 +411,10 @@
     "message": "重置节点",
     "description": "Reset Node"
   },
+  "Q/MbJP": {
+    "message": "请将这个短语存储在安全的地方。",
+    "description": "Please keep this phrase stored somewhere safe."
+  },
   "QS9NTE": {
     "message": "账户名称 —— 从A到Z",
     "description": "Account name — A to Z"
@@ -806,6 +810,10 @@
   "rfxp5c": {
     "message": "确认并发送",
     "description": "Confirm & Send"
+  },
+  "rqrhXg": {
+    "message": "确认您的恢复短语",
+    "description": "Confirm Your Recovery Phrase"
   },
   "tf+yHL": {
     "message": "快速",


### PR DESCRIPTION
We're missing translations in the ConfirmAccountStep component.

Fixes IFL-2123