### PR TITLE
@ironfish/sdk v1.16.0, electron v28.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "ironfish-node-app",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ironfish-node-app",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@ironfish/sdk": "1.15.0",
+        "@ironfish/sdk": "1.16.0",
         "electron-serve": "^1.1.0"
       },
       "devDependencies": {
@@ -45,7 +45,7 @@
         "date-fns": "^2.30.0",
         "date-fns-tz": "^2.0.0",
         "dotenv": "^16.3.1",
-        "electron": "28.0.0",
+        "electron": "28.1.4",
         "electron-builder": "^24.6.4",
         "electron-log": "5.0.0",
         "electron-store": "^8.1.0",
@@ -4516,26 +4516,26 @@
       "dev": true
     },
     "node_modules/@ironfish/rust-nodejs": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs/-/rust-nodejs-1.12.0.tgz",
-      "integrity": "sha512-S8BwCvxj5VBi70zSgBc4dh/ACEQwwTrmkSJBif8FSbF/6BfsykN+iL+dXw6eHGMZc+G5LZCj4ipoCkJ16a61Uw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs/-/rust-nodejs-1.13.0.tgz",
+      "integrity": "sha512-qjR8+qQwa0C9IxPcDutIyVa8ko5AIY6RM5N2kxU8+OygbP5o6uv/iIHMkntAai6bbbq3BjYFlppP4HdoyOwOvQ==",
       "engines": {
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@ironfish/rust-nodejs-darwin-arm64": "1.12.0",
-        "@ironfish/rust-nodejs-darwin-x64": "1.12.0",
-        "@ironfish/rust-nodejs-linux-arm64-gnu": "1.12.0",
-        "@ironfish/rust-nodejs-linux-arm64-musl": "1.12.0",
-        "@ironfish/rust-nodejs-linux-x64-gnu": "1.12.0",
-        "@ironfish/rust-nodejs-linux-x64-musl": "1.12.0",
-        "@ironfish/rust-nodejs-win32-x64-msvc": "1.12.0"
+        "@ironfish/rust-nodejs-darwin-arm64": "1.13.0",
+        "@ironfish/rust-nodejs-darwin-x64": "1.13.0",
+        "@ironfish/rust-nodejs-linux-arm64-gnu": "1.13.0",
+        "@ironfish/rust-nodejs-linux-arm64-musl": "1.13.0",
+        "@ironfish/rust-nodejs-linux-x64-gnu": "1.13.0",
+        "@ironfish/rust-nodejs-linux-x64-musl": "1.13.0",
+        "@ironfish/rust-nodejs-win32-x64-msvc": "1.13.0"
       }
     },
     "node_modules/@ironfish/rust-nodejs-darwin-arm64": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-arm64/-/rust-nodejs-darwin-arm64-1.12.0.tgz",
-      "integrity": "sha512-DBPp7ZyoMB1iE+NWmmHT9YGWNIxqwjslfUzSwRsx2MoS1HKrbMZ2XrfwJvlwdDwDhoNPlpKzmqqKDNpzkpgPZQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-arm64/-/rust-nodejs-darwin-arm64-1.13.0.tgz",
+      "integrity": "sha512-UCAIPnzgVLqjtk9PaXnqTpu7//vc4YEyG8Mij8I37Qs7l2U8SwQV0bAfi/DulY7TzEOKd2/OGvnLHP93k+JOpA==",
       "cpu": [
         "arm64"
       ],
@@ -4548,9 +4548,9 @@
       }
     },
     "node_modules/@ironfish/rust-nodejs-darwin-x64": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-x64/-/rust-nodejs-darwin-x64-1.12.0.tgz",
-      "integrity": "sha512-SLEzPIt+N/hm0l0NIq1yEgIAxM4khE78WHyRqoe1ZYsWRPFl+Az+1L4eLh6h6V3ibAgPr/KLrqWT5UKiiQ1mcQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-x64/-/rust-nodejs-darwin-x64-1.13.0.tgz",
+      "integrity": "sha512-fEN+L3iNUMTj5dgbnuMdDp6cGAwEzcuSeC5n00i/v1IBEbcimcMKWEl94cjZUOYVvYKDUYelvJ5OLZi8Rkat7w==",
       "cpu": [
         "x64"
       ],
@@ -4563,9 +4563,9 @@
       }
     },
     "node_modules/@ironfish/rust-nodejs-linux-arm64-gnu": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-gnu/-/rust-nodejs-linux-arm64-gnu-1.12.0.tgz",
-      "integrity": "sha512-MhNTauv8LXcbwwNP/O8nSo3ODKqzvUgJLmZJUQe/wSmlrDE0xISQe4epUYQnIemmjSqBoSxeq/X4NPNouFZznQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-gnu/-/rust-nodejs-linux-arm64-gnu-1.13.0.tgz",
+      "integrity": "sha512-GAFV+8c9UdG/c3g38eaNCjOvFMdyYZcWfIuuJiMWIavaOliZxyMqjAFHCdDB4XFGQl6xwfI8nQpZzIiCzrZ5Ng==",
       "cpu": [
         "arm64"
       ],
@@ -4578,9 +4578,9 @@
       }
     },
     "node_modules/@ironfish/rust-nodejs-linux-arm64-musl": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-musl/-/rust-nodejs-linux-arm64-musl-1.12.0.tgz",
-      "integrity": "sha512-0SY4E2wdObyfdF1jKH3MwsNMBIPrLOZn6J9+wMBFzgK39aG8SLe00YwPPyYLounsi1gFgbfKWJWaymMLdqCvrQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-musl/-/rust-nodejs-linux-arm64-musl-1.13.0.tgz",
+      "integrity": "sha512-MyBKm1K1/RsfpV0x+jMuBfJmjq8kPCYrzaRhyqkLuWKdeAa8zCBiBe9ntM6DQrcdWq0Z/dGEWCxrE2wiMnW4Ww==",
       "cpu": [
         "arm64"
       ],
@@ -4593,9 +4593,9 @@
       }
     },
     "node_modules/@ironfish/rust-nodejs-linux-x64-gnu": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-gnu/-/rust-nodejs-linux-x64-gnu-1.12.0.tgz",
-      "integrity": "sha512-S0ww+ibXb9fnw9HeHwdk/yL/6MJR9x+adKc7SsJlv9xpK7MKf+N9pK3ZvyXQ1Y4t7biTSsxEuDZRQSf7Bl/iDg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-gnu/-/rust-nodejs-linux-x64-gnu-1.13.0.tgz",
+      "integrity": "sha512-r5Pyn5KpzRLjyxTg7f7OSjqQXGRxnOG56Jvkcz6lVRCFCiikYqfUnT6T6Qf6Uwm72mrr3cO1AVx2eobB6PKIDQ==",
       "cpu": [
         "x64"
       ],
@@ -4608,9 +4608,9 @@
       }
     },
     "node_modules/@ironfish/rust-nodejs-linux-x64-musl": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-musl/-/rust-nodejs-linux-x64-musl-1.12.0.tgz",
-      "integrity": "sha512-jy3xUqIA8gFEGHe0IaGpfvyKpaC8sNGggJxjSHi4yxAMsCYwb5PCzSKQ5uoEvgTUreXS2bRecq5xUoiZRbApHQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-musl/-/rust-nodejs-linux-x64-musl-1.13.0.tgz",
+      "integrity": "sha512-l2zNeQkYBpH85skFZfDrcV/yORMKnYlieND9rU7+8DVkQigZM4kuRNX8spO7MHp0cyzwAML6Npvx3AoC81IyuQ==",
       "cpu": [
         "x64"
       ],
@@ -4623,9 +4623,9 @@
       }
     },
     "node_modules/@ironfish/rust-nodejs-win32-x64-msvc": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-win32-x64-msvc/-/rust-nodejs-win32-x64-msvc-1.12.0.tgz",
-      "integrity": "sha512-GDSy1gG/fsPrjIlq6raCPRoG2ue/Qs6wrGb/4d5+89uXvJgQBsaFN4F/18G4jkZ3rwJSRzY2umKqIRUiLJ4pUA==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-win32-x64-msvc/-/rust-nodejs-win32-x64-msvc-1.13.0.tgz",
+      "integrity": "sha512-2ZLAHBu+HfJ3K4VXexTzcnsykBxfQe70OCE+nRMZuuS4KrM+LAJhfoMcDfJ3WzM/99Lt3wRsQmcFxUyHHm71eA==",
       "cpu": [
         "x64"
       ],
@@ -4638,13 +4638,13 @@
       }
     },
     "node_modules/@ironfish/sdk": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/sdk/-/sdk-1.15.0.tgz",
-      "integrity": "sha512-GD+Mflz6LoelBxHcPtbApilJd9rp4YSIEeqGGGtf2Z3c7GidhRqpncJ2WiZobOF0wsoZr5u6Uhti0T+s6u0xwg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/sdk/-/sdk-1.16.0.tgz",
+      "integrity": "sha512-uQ3JbSvazCqmYgmLYVYrT8VTxoiirjAWSzG1tGjn+30x5HcHvzolkSY7VaTRK3YFf3zOAROzEyn6UK7uGw2VVw==",
       "dependencies": {
         "@ethersproject/bignumber": "5.7.0",
         "@fast-csv/format": "4.3.5",
-        "@ironfish/rust-nodejs": "1.12.0",
+        "@ironfish/rust-nodejs": "1.13.0",
         "@napi-rs/blake-hash": "1.3.3",
         "axios": "0.21.4",
         "bech32": "2.0.0",
@@ -8849,9 +8849,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "28.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-28.0.0.tgz",
-      "integrity": "sha512-eDhnCFBvG0PGFVEpNIEdBvyuGUBsFdlokd+CtuCe2ER3P+17qxaRfWRxMmksCOKgDHb5Wif5UxqOkZSlA4snlw==",
+      "version": "28.1.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-28.1.4.tgz",
+      "integrity": "sha512-WE6go611KOhtH6efRPMnVC7FE7DCKnQ3ZyHFeI1DbaCy8OU4UjZ8/CZGcuZmZgRdxSBEHoHdgaJkWRHZzF0FOg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "@ironfish/sdk": "1.15.0",
+    "@ironfish/sdk": "1.16.0",
     "electron-serve": "^1.1.0"
   },
   "devDependencies": {
@@ -57,7 +57,7 @@
     "date-fns": "^2.30.0",
     "date-fns-tz": "^2.0.0",
     "dotenv": "^16.3.1",
-    "electron": "28.0.0",
+    "electron": "28.1.4",
     "electron-builder": "^24.6.4",
     "electron-log": "5.0.0",
     "electron-store": "^8.1.0",


### PR DESCRIPTION
Bumps the ironfish SDK to v1.16.0 and electron to v28.1.4.