### PR TITLE
Bump Iron Fish SDK version to 1.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "ironfish-node-app",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ironfish-node-app",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@ironfish/sdk": "1.16.0",
+        "@ironfish/sdk": "1.18.0",
         "electron-serve": "^1.1.0"
       },
       "devDependencies": {
@@ -4516,26 +4516,26 @@
       "dev": true
     },
     "node_modules/@ironfish/rust-nodejs": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs/-/rust-nodejs-1.13.0.tgz",
-      "integrity": "sha512-qjR8+qQwa0C9IxPcDutIyVa8ko5AIY6RM5N2kxU8+OygbP5o6uv/iIHMkntAai6bbbq3BjYFlppP4HdoyOwOvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs/-/rust-nodejs-1.15.0.tgz",
+      "integrity": "sha512-8viJQKiwG3YfBRLGAGPQAyEFKTXg2zUyMxxzoUFHiG8mjasySwxuMNNXsHRNltfsQl/YkM/F17i5k+yTUPiwyQ==",
       "engines": {
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@ironfish/rust-nodejs-darwin-arm64": "1.13.0",
-        "@ironfish/rust-nodejs-darwin-x64": "1.13.0",
-        "@ironfish/rust-nodejs-linux-arm64-gnu": "1.13.0",
-        "@ironfish/rust-nodejs-linux-arm64-musl": "1.13.0",
-        "@ironfish/rust-nodejs-linux-x64-gnu": "1.13.0",
-        "@ironfish/rust-nodejs-linux-x64-musl": "1.13.0",
-        "@ironfish/rust-nodejs-win32-x64-msvc": "1.13.0"
+        "@ironfish/rust-nodejs-darwin-arm64": "1.15.0",
+        "@ironfish/rust-nodejs-darwin-x64": "1.15.0",
+        "@ironfish/rust-nodejs-linux-arm64-gnu": "1.15.0",
+        "@ironfish/rust-nodejs-linux-arm64-musl": "1.15.0",
+        "@ironfish/rust-nodejs-linux-x64-gnu": "1.15.0",
+        "@ironfish/rust-nodejs-linux-x64-musl": "1.15.0",
+        "@ironfish/rust-nodejs-win32-x64-msvc": "1.15.0"
       }
     },
     "node_modules/@ironfish/rust-nodejs-darwin-arm64": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-arm64/-/rust-nodejs-darwin-arm64-1.13.0.tgz",
-      "integrity": "sha512-UCAIPnzgVLqjtk9PaXnqTpu7//vc4YEyG8Mij8I37Qs7l2U8SwQV0bAfi/DulY7TzEOKd2/OGvnLHP93k+JOpA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-arm64/-/rust-nodejs-darwin-arm64-1.15.0.tgz",
+      "integrity": "sha512-6utH+vmu+G22rCJZ+XmliKmjyEf/8QSBpadq3nJw6Kb4HwqXFpbFoSVJOVEmzPHr/NBC/aydR01qQyKNrnNIAw==",
       "cpu": [
         "arm64"
       ],
@@ -4548,9 +4548,9 @@
       }
     },
     "node_modules/@ironfish/rust-nodejs-darwin-x64": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-x64/-/rust-nodejs-darwin-x64-1.13.0.tgz",
-      "integrity": "sha512-fEN+L3iNUMTj5dgbnuMdDp6cGAwEzcuSeC5n00i/v1IBEbcimcMKWEl94cjZUOYVvYKDUYelvJ5OLZi8Rkat7w==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-x64/-/rust-nodejs-darwin-x64-1.15.0.tgz",
+      "integrity": "sha512-SI06CbOtwtkTSes6lfeWuwwjmo0Gq4JK5umVb5wb/aG/atrdZEHtoRYw7C93JEvSzpPxaELpbGhYcsUaSMkLYQ==",
       "cpu": [
         "x64"
       ],
@@ -4563,9 +4563,9 @@
       }
     },
     "node_modules/@ironfish/rust-nodejs-linux-arm64-gnu": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-gnu/-/rust-nodejs-linux-arm64-gnu-1.13.0.tgz",
-      "integrity": "sha512-GAFV+8c9UdG/c3g38eaNCjOvFMdyYZcWfIuuJiMWIavaOliZxyMqjAFHCdDB4XFGQl6xwfI8nQpZzIiCzrZ5Ng==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-gnu/-/rust-nodejs-linux-arm64-gnu-1.15.0.tgz",
+      "integrity": "sha512-kzHW6Jo0ReZOYytXfTECcwzQPCYNu6NoFIALlNmw6Q0Au9yNpSI+sKDeAJ6OToZzp17G93K4e0wrBxSYsQp9mQ==",
       "cpu": [
         "arm64"
       ],
@@ -4578,9 +4578,9 @@
       }
     },
     "node_modules/@ironfish/rust-nodejs-linux-arm64-musl": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-musl/-/rust-nodejs-linux-arm64-musl-1.13.0.tgz",
-      "integrity": "sha512-MyBKm1K1/RsfpV0x+jMuBfJmjq8kPCYrzaRhyqkLuWKdeAa8zCBiBe9ntM6DQrcdWq0Z/dGEWCxrE2wiMnW4Ww==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-musl/-/rust-nodejs-linux-arm64-musl-1.15.0.tgz",
+      "integrity": "sha512-Vw0QhwNNCDYmil8xs5/XfJ2yrjUSJM8DUNjzUjiNlNWFbYcV7RfrhdAnAChuBF9FKPpiqBTpWV1EX8erKOHWWQ==",
       "cpu": [
         "arm64"
       ],
@@ -4593,9 +4593,9 @@
       }
     },
     "node_modules/@ironfish/rust-nodejs-linux-x64-gnu": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-gnu/-/rust-nodejs-linux-x64-gnu-1.13.0.tgz",
-      "integrity": "sha512-r5Pyn5KpzRLjyxTg7f7OSjqQXGRxnOG56Jvkcz6lVRCFCiikYqfUnT6T6Qf6Uwm72mrr3cO1AVx2eobB6PKIDQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-gnu/-/rust-nodejs-linux-x64-gnu-1.15.0.tgz",
+      "integrity": "sha512-YMexdhV0Iv26SSrssTZvFw5oCeZMKJh+uWfPaCPh3fUfMo0STJ1Y+RCX8JwbM9pTkw7Sn5OS6E3L36v8Onwa/w==",
       "cpu": [
         "x64"
       ],
@@ -4608,9 +4608,9 @@
       }
     },
     "node_modules/@ironfish/rust-nodejs-linux-x64-musl": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-musl/-/rust-nodejs-linux-x64-musl-1.13.0.tgz",
-      "integrity": "sha512-l2zNeQkYBpH85skFZfDrcV/yORMKnYlieND9rU7+8DVkQigZM4kuRNX8spO7MHp0cyzwAML6Npvx3AoC81IyuQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-musl/-/rust-nodejs-linux-x64-musl-1.15.0.tgz",
+      "integrity": "sha512-IxFQ9o8yOxD+Z1q/Veehr5I/cD09AOOZR++JGq/glewllT2xv2d+NFVYDvCTtzr5XG6/V0S1w+XqgAkgXYL5og==",
       "cpu": [
         "x64"
       ],
@@ -4623,9 +4623,9 @@
       }
     },
     "node_modules/@ironfish/rust-nodejs-win32-x64-msvc": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-win32-x64-msvc/-/rust-nodejs-win32-x64-msvc-1.13.0.tgz",
-      "integrity": "sha512-2ZLAHBu+HfJ3K4VXexTzcnsykBxfQe70OCE+nRMZuuS4KrM+LAJhfoMcDfJ3WzM/99Lt3wRsQmcFxUyHHm71eA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-win32-x64-msvc/-/rust-nodejs-win32-x64-msvc-1.15.0.tgz",
+      "integrity": "sha512-0xmuViZrABdBU298N7VsQh6UzIVuth3esG+gCq6hynweuAznQ08YOs0bQA9jOiHcOGwNNYKJUgpLTCPmXuSynA==",
       "cpu": [
         "x64"
       ],
@@ -4638,13 +4638,13 @@
       }
     },
     "node_modules/@ironfish/sdk": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/sdk/-/sdk-1.16.0.tgz",
-      "integrity": "sha512-uQ3JbSvazCqmYgmLYVYrT8VTxoiirjAWSzG1tGjn+30x5HcHvzolkSY7VaTRK3YFf3zOAROzEyn6UK7uGw2VVw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/sdk/-/sdk-1.18.0.tgz",
+      "integrity": "sha512-gmOyoXZ48K7BEwwnWjHr1ncVo886o7xZa74qN5uifDe6Y8p9l2mT3kvo3Ekt45IUT12HxAE7Azazud4GVv1mhA==",
       "dependencies": {
         "@ethersproject/bignumber": "5.7.0",
         "@fast-csv/format": "4.3.5",
-        "@ironfish/rust-nodejs": "1.13.0",
+        "@ironfish/rust-nodejs": "1.15.0",
         "@napi-rs/blake-hash": "1.3.3",
         "axios": "0.21.4",
         "bech32": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "@ironfish/sdk": "1.16.0",
+    "@ironfish/sdk": "1.18.0",
     "electron-serve": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Upgrades `@ironfish/sdk` version to 1.18.0 to fix issue when `hosts.json` file is empty.