### PR TITLE
Remove unneeded network identity construction

### DIFF
--- a/main/api/ironfish/Ironfish.ts
+++ b/main/api/ironfish/Ironfish.ts
@@ -105,13 +105,6 @@ export class Ironfish {
         }
       }
 
-      const newSecretKey = Buffer.from(
-        node.peerNetwork.localPeer.privateIdentity.secretKey,
-      ).toString("hex");
-
-      node.internal.set("networkIdentity", newSecretKey);
-      await node.internal.save();
-
       if (node.internal.get("isFirstRun")) {
         node.internal.set("isFirstRun", false);
         node.internal.set("telemetryNodeId", uuid());


### PR DESCRIPTION
The need for this was removed from the SDK in https://github.com/iron-fish/ironfish/pull/4540, so it simplifies the startup process a bit.