### PR TITLE
Make transaction hash copyable

### DIFF
--- a/renderer/components/CopyAddress/CopyAddress.tsx
+++ b/renderer/components/CopyAddress/CopyAddress.tsx
@@ -15,10 +15,16 @@ const messages = defineMessages({
 
 type Props = TextProps & {
   address: string;
+  parts?: 2 | 3;
   truncate?: boolean;
 };
 
-export function CopyAddress({ address, truncate = true, ...rest }: Props) {
+export function CopyAddress({
+  address,
+  parts = 3,
+  truncate = true,
+  ...rest
+}: Props) {
   const [_, copyToClipboard] = useCopyToClipboard();
   const toast = useIFToast();
   const { formatMessage } = useIntl();
@@ -42,7 +48,7 @@ export function CopyAddress({ address, truncate = true, ...rest }: Props) {
       }}
       {...rest}
     >
-      {truncate ? truncateString(address) : address}
+      {truncate ? truncateString(address, parts) : address}
       <CopyIcon
         color={COLORS.GRAY_MEDIUM}
         _dark={{ color: COLORS.DARK_MODE.GRAY_LIGHT }}

--- a/renderer/components/TransactionInformation/TransactionInformation.tsx
+++ b/renderer/components/TransactionInformation/TransactionInformation.tsx
@@ -23,7 +23,8 @@ import { COLORS } from "@/ui/colors";
 import { ShadowCard } from "@/ui/ShadowCard/ShadowCard";
 import { formatDate } from "@/utils/formatDate";
 import { formatOre } from "@/utils/ironUtils";
-import { truncateString } from "@/utils/truncateString";
+
+import { CopyAddress } from "../CopyAddress/CopyAddress";
 
 type Transaction = TRPCRouterOutputs["getTransaction"]["transaction"];
 
@@ -64,7 +65,15 @@ const ITEMS = [
   {
     label: messages.transactionHash,
     icon: <Image src={pinkHash} alt="" />,
-    render: (transaction: Transaction) => truncateString(transaction.hash, 2),
+    render: (transaction: Transaction) => (
+      <CopyAddress
+        fontSize="md"
+        color={COLORS.BLACK}
+        _dark={{ color: COLORS.WHITE }}
+        address={transaction.hash}
+        parts={2}
+      />
+    ),
   },
   {
     label: messages.timestamp,


### PR DESCRIPTION
There was a user in Discord who asked if it would be possible to copy the transaction hash -- since we don't display the transaction hash un-truncated anywhere in the app, I think we should at least make the transaction hash copyable.

<img width="1215" alt="image" src="https://github.com/iron-fish/ironfish-node-app/assets/767083/1dd53ff0-19ac-4c61-841b-4997457eebe5">

Fixes IFL-2135
