### PR TITLE
Migrate address book on app start and delete old address book

### DIFF
--- a/main/api/contacts/index.ts
+++ b/main/api/contacts/index.ts
@@ -2,10 +2,6 @@ import Store, { Schema } from "electron-store";
 import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
 
-import {
-  deleteNodeAppBetaContacts,
-  getNodeAppBetaContacts,
-} from "./utils/getNodeAppBetaContacts";
 import { t } from "../trpc";
 
 const contactDefinition = z.object({
@@ -38,7 +34,7 @@ const schema: Schema<{
   },
 };
 
-const store = new Store({ schema, name: "contacts" });
+export const store = new Store({ schema, name: "contacts" });
 
 export const contactsRouter = t.router({
   getContacts: t.procedure.query(async () => {
@@ -57,28 +53,6 @@ export const contactsRouter = t.router({
         null
       );
     }),
-  migrateNodeAppBetaContacts: t.procedure.mutation(async () => {
-    const betaContacts = await getNodeAppBetaContacts();
-    const contacts = store.get("contacts", []);
-    const addressLookup = new Set(contacts.map((contact) => contact.address));
-
-    let order = 0;
-
-    for (const contact of betaContacts) {
-      if (!addressLookup.has(contact.address)) {
-        contacts.push({
-          id: uuidv4(),
-          name: contact.name,
-          address: contact.address,
-          order: order++,
-        });
-      }
-    }
-
-    store.set("contacts", contacts);
-    deleteNodeAppBetaContacts();
-    return contacts;
-  }),
   addContact: t.procedure
     .input(
       z.object({
@@ -94,7 +68,7 @@ export const contactsRouter = t.router({
         address: opts.input.address,
         order: contacts.length,
       });
-      store.set("contacts", contacts);
+      contactsStore.set("contacts", contacts);
       return contacts;
     }),
   editContact: t.procedure

--- a/main/api/contacts/index.ts
+++ b/main/api/contacts/index.ts
@@ -2,7 +2,10 @@ import Store, { Schema } from "electron-store";
 import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
 
-import { getNodeAppBetaContacts } from "./utils/getNodeAppBetaContacts";
+import {
+  deleteNodeAppBetaContacts,
+  getNodeAppBetaContacts,
+} from "./utils/getNodeAppBetaContacts";
 import { t } from "../trpc";
 
 const contactDefinition = z.object({
@@ -56,7 +59,7 @@ export const contactsRouter = t.router({
     }),
   migrateNodeAppBetaContacts: t.procedure.mutation(async () => {
     const betaContacts = await getNodeAppBetaContacts();
-    const contacts = await store.get("contacts", []);
+    const contacts = store.get("contacts", []);
     const addressLookup = new Set(contacts.map((contact) => contact.address));
 
     let order = 0;
@@ -73,6 +76,7 @@ export const contactsRouter = t.router({
     }
 
     store.set("contacts", contacts);
+    deleteNodeAppBetaContacts();
     return contacts;
   }),
   addContact: t.procedure

--- a/main/api/contacts/index.ts
+++ b/main/api/contacts/index.ts
@@ -68,7 +68,7 @@ export const contactsRouter = t.router({
         address: opts.input.address,
         order: contacts.length,
       });
-      contactsStore.set("contacts", contacts);
+      store.set("contacts", contacts);
       return contacts;
     }),
   editContact: t.procedure

--- a/main/api/contacts/utils/getNodeAppBetaContacts.ts
+++ b/main/api/contacts/utils/getNodeAppBetaContacts.ts
@@ -40,3 +40,15 @@ export function getNodeAppBetaContacts(): Promise<Array<BetaContact>> {
     });
   });
 }
+
+export function deleteNodeAppBetaContacts(): void {
+  const betaContactsDbPath = path.join(
+    os.homedir(),
+    "/.ironfish/node-app",
+    "address_book.db",
+  );
+
+  if (fs.existsSync(betaContactsDbPath)) {
+    fs.rmSync(betaContactsDbPath);
+  }
+}

--- a/main/api/contacts/utils/migrateNodeAppBetaContacts.ts
+++ b/main/api/contacts/utils/migrateNodeAppBetaContacts.ts
@@ -3,6 +3,9 @@ import os from "os";
 import path from "path";
 
 import NeDBStorage from "nedb";
+import { v4 as uuidv4 } from "uuid";
+
+import { store } from "..";
 
 type BetaContact = {
   name: string;
@@ -11,7 +14,7 @@ type BetaContact = {
 
 let nedb: NeDBStorage;
 
-export function getNodeAppBetaContacts(): Promise<Array<BetaContact>> {
+function getNodeAppBetaContacts(): Promise<Array<BetaContact>> {
   const betaContactsDbPath = path.join(
     os.homedir(),
     "/.ironfish/node-app",
@@ -41,7 +44,7 @@ export function getNodeAppBetaContacts(): Promise<Array<BetaContact>> {
   });
 }
 
-export function deleteNodeAppBetaContacts(): void {
+function deleteNodeAppBetaContacts(): void {
   const betaContactsDbPath = path.join(
     os.homedir(),
     "/.ironfish/node-app",
@@ -51,4 +54,27 @@ export function deleteNodeAppBetaContacts(): void {
   if (fs.existsSync(betaContactsDbPath)) {
     fs.rmSync(betaContactsDbPath);
   }
+}
+
+export async function migrateNodeAppBetaContacts() {
+  const betaContacts = await getNodeAppBetaContacts();
+  const contacts = store.get("contacts", []);
+  const addressLookup = new Set(contacts.map((contact) => contact.address));
+
+  let order = 0;
+
+  for (const contact of betaContacts) {
+    if (!addressLookup.has(contact.address)) {
+      contacts.push({
+        id: uuidv4(),
+        name: contact.name,
+        address: contact.address,
+        order: order++,
+      });
+    }
+  }
+
+  store.set("contacts", contacts);
+  deleteNodeAppBetaContacts();
+  return contacts;
 }

--- a/main/background.ts
+++ b/main/background.ts
@@ -4,6 +4,7 @@ import serve from "electron-serve";
 import { createIPCHandler } from "electron-trpc/main";
 
 import { router } from "./api";
+import { migrateNodeAppBetaContacts } from "./api/contacts/utils/migrateNodeAppBetaContacts";
 import { manager } from "./api/manager";
 import { getUserSettings } from "./api/user-settings/userSettings";
 import { mainWindow } from "./main-window";
@@ -79,6 +80,7 @@ app.whenReady().then(() => {
 
   createThemeChangeHandler();
   setNativeThemeSource();
+  migrateNodeAppBetaContacts();
 
   const handler = createIPCHandler({ router });
 

--- a/renderer/pages/home.tsx
+++ b/renderer/pages/home.tsx
@@ -19,14 +19,6 @@ export default function Home() {
 
   const { mutate: startNode } = trpcReact.startNode.useMutation();
 
-  const { mutate: migrateContacts } =
-    trpcReact.migrateNodeAppBetaContacts.useMutation();
-
-  // Trigger contact migration when the app starts up
-  useEffect(() => {
-    migrateContacts();
-  }, [migrateContacts]);
-
   // If user has no accounts, go to onboarding
   useEffect(() => {
     if (initialStateData === "onboarding") {

--- a/renderer/pages/home.tsx
+++ b/renderer/pages/home.tsx
@@ -19,6 +19,14 @@ export default function Home() {
 
   const { mutate: startNode } = trpcReact.startNode.useMutation();
 
+  const { mutate: migrateContacts } =
+    trpcReact.migrateNodeAppBetaContacts.useMutation();
+
+  // Trigger contact migration when the app starts up
+  useEffect(() => {
+    migrateContacts();
+  }, [migrateContacts]);
+
   // If user has no accounts, go to onboarding
   useEffect(() => {
     if (initialStateData === "onboarding") {


### PR DESCRIPTION
Added address book migration when the app starts up. One change I made was to delete the old address book after migrating it, since otherwise if you delete a contact after migrating address books, it'll re-migrate the contact on next app start.

I tested creating an address book in the old app and ensuring that it migrates to the new app, as well as making sure conflicts are resolved with the newer app's contact.

Fixes IFL-2156
