### PR TITLE
Skip re-querying fees when typing in memo

### DIFF
--- a/renderer/components/SendAssetsForm/SendAssetsForm.tsx
+++ b/renderer/components/SendAssetsForm/SendAssetsForm.tsx
@@ -144,7 +144,6 @@ export function SendAssetsFormContent({
   const feeValue = watch("fee");
   const amountValue = watch("amount");
   const toAccountValue = watch("toAccount");
-  const memoValue = watch("memo");
 
   const { data: estimatedFeesData, error: estimatedFeesError } =
     trpcReact.getEstimatedFees.useQuery(
@@ -153,7 +152,7 @@ export function SendAssetsFormContent({
         output: {
           amount: parseIron(amountValue),
           assetId: assetValue,
-          memo: memoValue ?? "",
+          memo: "",
           publicAddress: toAccountValue,
         },
       },


### PR DESCRIPTION
The memo field isn't really relevant to calculating estimated fees, and the fee selector flickers as the fee is re-fetched.

There might be one or more better fixes here, like caching the previous estimated fees, but we have designs to move the fee selection to the confirmation dialog, which will simplify the fee fetching flow a lot anyway

Fixes IFL-2160
