### PR TITLE
Prevent typing in memo field when at max memo length

### DIFF
--- a/renderer/components/SendAssetsForm/SendAssetsForm.tsx
+++ b/renderer/components/SendAssetsForm/SendAssetsForm.tsx
@@ -2,7 +2,7 @@ import { VStack, chakra, HStack } from "@chakra-ui/react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/router";
 import { useEffect, useMemo, useState } from "react";
-import { useForm } from "react-hook-form";
+import { useForm, Controller } from "react-hook-form";
 import { useIntl, defineMessages } from "react-intl";
 
 import { TRPCRouterOutputs, trpcReact } from "@/providers/TRPCProvider";
@@ -14,10 +14,12 @@ import { PillButton } from "@/ui/PillButton/PillButton";
 import { hexToUTF16String } from "@/utils/hexToUTF16String";
 import { formatOre, parseIron } from "@/utils/ironUtils";
 import { asQueryString } from "@/utils/parseRouteQuery";
+import { sliceToUtf8Bytes } from "@/utils/sliceToUtf8Bytes";
 import { truncateString } from "@/utils/truncateString";
 
 import { ConfirmTransactionModal } from "./ConfirmTransactionModal/ConfirmTransactionModal";
 import {
+  MAX_MEMO_SIZE,
   TransactionData,
   TransactionFormData,
   transactionSchema,
@@ -121,6 +123,7 @@ export function SendAssetsFormContent({
 
   const {
     register,
+    control,
     handleSubmit,
     formState: { errors },
     watch,
@@ -339,10 +342,21 @@ export function SendAssetsFormContent({
             error={errors.fee?.message}
           />
 
-          <TextInput
-            {...register("memo")}
-            label={formatMessage(messages.memoLabel)}
-            error={errors.memo?.message}
+          <Controller
+            name="memo"
+            control={control}
+            render={({ field }) => (
+              <TextInput
+                {...field}
+                onChange={(e) =>
+                  field.onChange(
+                    sliceToUtf8Bytes(e.target.value, MAX_MEMO_SIZE),
+                  )
+                }
+                label={formatMessage(messages.memoLabel)}
+                error={errors.memo?.message}
+              />
+            )}
           />
 
           <RenderError

--- a/renderer/components/SendAssetsForm/transactionSchema.ts
+++ b/renderer/components/SendAssetsForm/transactionSchema.ts
@@ -2,6 +2,9 @@ import * as z from "zod";
 
 import { getTrpcVanillaClient } from "@/providers/TRPCProvider";
 import { MIN_IRON_VALUE } from "@/utils/ironUtils";
+import { sliceToUtf8Bytes } from "@/utils/sliceToUtf8Bytes";
+
+export const MAX_MEMO_SIZE = 32;
 
 export const transactionSchema = z.object({
   fromAccount: z.string().min(1),
@@ -18,7 +21,13 @@ export const transactionSchema = z.object({
   assetId: z.string().min(1),
   amount: z.coerce.number().min(MIN_IRON_VALUE),
   fee: z.union([z.literal("slow"), z.literal("average"), z.literal("fast")]),
-  memo: z.string().max(32).optional(),
+  memo: z
+    .string()
+    .refine(
+      (s) => s === sliceToUtf8Bytes(s, MAX_MEMO_SIZE),
+      "Memo can't be more than 32 bytes",
+    )
+    .optional(),
 });
 
 export type TransactionFormData = z.infer<typeof transactionSchema>;

--- a/renderer/utils/sliceToUtf8Bytes.ts
+++ b/renderer/utils/sliceToUtf8Bytes.ts
@@ -1,0 +1,15 @@
+/**
+ * Slices a string to a given number of bytes (calling .slice on a string would otherwise limit the number of characters)
+ */
+export function sliceToUtf8Bytes(input: string, bytes: number) {
+  new TextEncoder();
+  let sliced = input.slice(0, bytes);
+
+  const encoder = new TextEncoder();
+
+  while (encoder.encode(sliced).byteLength > bytes) {
+    sliced = sliced.slice(0, sliced.length - 1);
+  }
+
+  return sliced;
+}


### PR DESCRIPTION
Prevents changing the memo field when at the max memo length, and also updates the field to only take 32 bytes (utf-8 encoded). This input would get silently truncated by the node when creating the transaction otherwise (I don't think the CLI even handles this properly).

Fixes IFL-2159
