### PR TITLE
Add link to block explorer to transaction details

### DIFF
--- a/renderer/components/TransactionInformation/TransactionInformation.tsx
+++ b/renderer/components/TransactionInformation/TransactionInformation.tsx
@@ -18,7 +18,7 @@ import pinkCube from "@/images/pink-cube.svg";
 import pinkHash from "@/images/pink-hash.svg";
 import pinkInformation from "@/images/pink-information.svg";
 import pinkSquareStack from "@/images/pink-square-stack.svg";
-import { TRPCRouterOutputs } from "@/providers/TRPCProvider";
+import { trpcReact, TRPCRouterOutputs } from "@/providers/TRPCProvider";
 import { COLORS } from "@/ui/colors";
 import { ShadowCard } from "@/ui/ShadowCard/ShadowCard";
 import { formatDate } from "@/utils/formatDate";
@@ -54,7 +54,44 @@ const messages = defineMessages({
   transactionInformation: {
     defaultMessage: "Transaction Information",
   },
+  viewInBlockExplorer: {
+    defaultMessage: "View in Block Explorer",
+  },
 });
+
+function TransactionHashBody({ transaction }: { transaction: Transaction }) {
+  const { data } = trpcReact.getExplorerUrl.useQuery({
+    type: "transaction",
+    hash: transaction.hash,
+  });
+
+  const { formatMessage } = useIntl();
+
+  return (
+    <VStack alignItems="flex-start">
+      <CopyAddress
+        fontSize="md"
+        color={COLORS.BLACK}
+        _dark={{ color: COLORS.WHITE }}
+        address={transaction.hash}
+        parts={2}
+      />
+      {data && (
+        <Box
+          as="a"
+          target="_blank"
+          display="inline"
+          href={data}
+          _hover={{ textDecor: "underline" }}
+        >
+          <Text fontSize="xs" lineHeight="160%">
+            {formatMessage(messages.viewInBlockExplorer)}
+          </Text>
+        </Box>
+      )}
+    </VStack>
+  );
+}
 
 const ITEMS = [
   {
@@ -66,13 +103,7 @@ const ITEMS = [
     label: messages.transactionHash,
     icon: <Image src={pinkHash} alt="" />,
     render: (transaction: Transaction) => (
-      <CopyAddress
-        fontSize="md"
-        color={COLORS.BLACK}
-        _dark={{ color: COLORS.WHITE }}
-        address={transaction.hash}
-        parts={2}
-      />
+      <TransactionHashBody transaction={transaction} />
     ),
   },
   {

--- a/renderer/intl/locales/en-US.json
+++ b/renderer/intl/locales/en-US.json
@@ -618,6 +618,9 @@
   "rqrhXg": {
     "message": "Confirm Your Recovery Phrase"
   },
+  "tU2A8W": {
+    "message": "View in Block Explorer"
+  },
   "tf+yHL": {
     "message": "Fast"
   },

--- a/renderer/intl/locales/es-MX.json
+++ b/renderer/intl/locales/es-MX.json
@@ -823,6 +823,10 @@
     "message": "Confirma tu Frase de Recuperación",
     "description": "Confirm Your Recovery Phrase"
   },
+  "tU2A8W": {
+    "message": "Ver en Block Explorer",
+    "description": "View in Block Explorer"
+  },
   "tf+yHL": {
     "message": "Rápido",
     "description": "Fast"

--- a/renderer/intl/locales/ru-RU.json
+++ b/renderer/intl/locales/ru-RU.json
@@ -823,6 +823,10 @@
     "message": "Подтвердите вашу фразу восстановления",
     "description": "Confirm Your Recovery Phrase"
   },
+  "tU2A8W": {
+    "message": "Посмотреть в Block Explorer",
+    "description": "View in Block Explorer"
+  },
   "tf+yHL": {
     "message": "Быстро",
     "description": "Fast"

--- a/renderer/intl/locales/uk-UA.json
+++ b/renderer/intl/locales/uk-UA.json
@@ -823,6 +823,10 @@
     "message": "Підтвердіть вашу фразу відновлення",
     "description": "Confirm Your Recovery Phrase"
   },
+  "tU2A8W": {
+    "message": "Переглянути в Block Explorer",
+    "description": "View in Block Explorer"
+  },
   "tf+yHL": {
     "message": "Швидко",
     "description": "Fast"

--- a/renderer/intl/locales/zh-CN.json
+++ b/renderer/intl/locales/zh-CN.json
@@ -823,6 +823,10 @@
     "message": "确认您的恢复短语",
     "description": "Confirm Your Recovery Phrase"
   },
+  "tU2A8W": {
+    "message": "在Block Explorer中查看",
+    "description": "View in Block Explorer"
+  },
   "tf+yHL": {
     "message": "快速",
     "description": "Fast"


### PR DESCRIPTION
Adds a link to the block explorer in with the Transaction Hash on the transaction details page.

Fixes IFL-2157

![image](https://github.com/iron-fish/ironfish-node-app/assets/767083/75d8e017-8206-4cb1-814b-ad3467ecde95)

