### PR TITLE
Escape paths correctly in `extract:i18n`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepare": "husky install",
     "postinstall": "electron-builder install-app-deps",
     "release": "npm run i18n && nextron build --publish always",
-    "extract:i18n": "formatjs extract renderer/{pages,components,sections,layouts,ui}/**/*.{js,ts,tsx} --format crowdin --id-interpolation-pattern \"[sha512:contenthash:base64:6]\" --out-file renderer/intl/locales/en-US.json",
+    "extract:i18n": "formatjs extract \"renderer/{pages,components,sections,layouts,ui}/**/*.{js,ts,tsx}\" --format crowdin --id-interpolation-pattern \"[sha512:contenthash:base64:6]\" --out-file renderer/intl/locales/en-US.json",
     "compile:i18n": "formatjs compile-folder --ast --format crowdin renderer/intl/locales renderer/intl/compiled-locales",
     "i18n": "npm run extract:i18n && npm run compile:i18n",
     "translate": "tsx scripts/openai-translator.ts",


### PR DESCRIPTION
Tested on both Windows and Mac to make sure that running `extract:i18n` doesn't create incorrect extractions on either OS.

Fixes IFL-2302