### PR TITLE
switch networks POC

### DIFF
--- a/main/api/ironfish/index.ts
+++ b/main/api/ironfish/index.ts
@@ -77,9 +77,21 @@ export const ironfishRouter = t.router({
     const response = await rpcClient.node.getStatus();
     return response.content;
   }),
-  getInitialState: t.procedure.query(async () => {
-    return manager.getInitialState();
-  }),
+  getInitialState: t.procedure
+    .input(
+      z
+        .object({
+          seed: z.string().optional(),
+        })
+        .optional(),
+    )
+    .query(
+      async ({
+        input: _, // Hack to skip the cache. Trpc doesn't support queryKey yet.
+      }) => {
+        return await manager.getInitialState();
+      },
+    ),
   shouldDownloadSnapshot: t.procedure.query(async () => {
     return manager.shouldDownloadSnapshot();
   }),
@@ -113,4 +125,14 @@ export const ironfishRouter = t.router({
     const ironfish = await manager.getIronfish();
     await ironfish.start();
   }),
+  changeNetwork: t.procedure
+    .input(
+      z.object({
+        network: z.enum(["MAINNET", "TESTNET"]),
+      }),
+    )
+    .mutation(async (opts) => {
+      const ironfish = await manager.getIronfish();
+      await ironfish.changeNetwork(opts.input.network === "MAINNET" ? 1 : 0);
+    }),
 });

--- a/main/api/manager.ts
+++ b/main/api/manager.ts
@@ -10,14 +10,15 @@ export type InitialState =
 
 export class Manager {
   private _ironfish: Ironfish | null = null;
-  private _initialState: InitialState | null = null;
 
   async getIronfish(): Promise<Ironfish> {
     if (this._ironfish) return this._ironfish;
 
     const userSettings = await getUserSettings();
-    const dataDir = userSettings.get("dataDir");
-    this._ironfish = new Ironfish(dataDir);
+    const networkId = userSettings.get("networkId");
+    this._ironfish = new Ironfish({
+      networkId,
+    });
     return this._ironfish;
   }
 
@@ -36,8 +37,6 @@ export class Manager {
   };
 
   async getInitialState(): Promise<InitialState> {
-    if (this._initialState) return this._initialState;
-
     const ironfish = await this.getIronfish();
 
     if (!ironfish.isStarted()) {

--- a/main/api/snapshot/index.ts
+++ b/main/api/snapshot/index.ts
@@ -36,6 +36,10 @@ export const snapshotRouter = t.router({
     }),
   downloadSnapshot: t.procedure.mutation(async () => {
     const ironfish = await manager.getIronfish();
+    if (ironfish.isStarted()) {
+      await ironfish.stop();
+      await ironfish.init();
+    }
     ironfish.downloadSnapshot();
   }),
 });

--- a/main/api/user-settings/userSettings.ts
+++ b/main/api/user-settings/userSettings.ts
@@ -1,11 +1,11 @@
-import { DEFAULT_DATA_DIR, NodeFileProvider } from "@ironfish/sdk";
+import { DEFAULT_NETWORK_ID, NodeFileProvider } from "@ironfish/sdk";
 import Store, { Schema } from "electron-store";
 import { z } from "zod";
 
 const STORE_NAME = "user-settings";
 
 export const settingsZodSchema = z.object({
-  dataDir: z.string(),
+  networkId: z.number(),
   theme: z.enum(["light", "dark", "system"]),
   locale: z.string().nullable(),
 });
@@ -13,8 +13,8 @@ export const settingsZodSchema = z.object({
 export type SchemaDefinition = z.infer<typeof settingsZodSchema>;
 
 export const settingsSchema: Schema<SchemaDefinition> = {
-  dataDir: {
-    type: "string",
+  networkId: {
+    type: "number",
   },
   theme: {
     enum: ["light", "dark", "system"],
@@ -36,7 +36,7 @@ export async function getUserSettings() {
     schema: settingsSchema,
     name: STORE_NAME,
     defaults: {
-      dataDir: fileSystem.resolve(DEFAULT_DATA_DIR),
+      networkId: DEFAULT_NETWORK_ID,
       theme: "system",
       locale: null,
     },

--- a/renderer/components/LanguageSelector/LanguageSelector.tsx
+++ b/renderer/components/LanguageSelector/LanguageSelector.tsx
@@ -1,23 +1,23 @@
 import {
-  Text,
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalBody,
-  Heading,
-  ModalFooter,
-  useDisclosure,
-  Flex,
   Box,
+  Flex,
   FlexProps,
+  Heading,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalOverlay,
+  Text,
+  useDisclosure,
 } from "@chakra-ui/react";
 import { useForm } from "react-hook-form";
-import { FaChevronDown } from "react-icons/fa";
+import { FaChevronRight } from "react-icons/fa";
 import { MdOutlineLanguage } from "react-icons/md";
 import { defineMessages, useIntl } from "react-intl";
 import { z } from "zod";
 
-import { useSelectedLocaleContext, Locales } from "@/intl/IntlProvider";
+import { Locales, useSelectedLocaleContext } from "@/intl/IntlProvider";
 import { COLORS } from "@/ui/colors";
 import { Select } from "@/ui/Forms/Select/Select";
 import { PillButton } from "@/ui/PillButton/PillButton";
@@ -111,9 +111,16 @@ export function LanguageSelector({ buttonContainerProps }: Props) {
         borderRadius="5px"
         bg={COLORS.GRAY_LIGHT}
         color={COLORS.GRAY_MEDIUM}
-        justifyContent="center"
+        justifyContent={{
+          base: "center",
+          md: "space-between",
+        }}
         alignItems="center"
         py="6px"
+        px={{
+          base: 0,
+          md: "18px",
+        }}
         _dark={{
           bg: COLORS.DARK_MODE.GRAY_MEDIUM,
           color: COLORS.DARK_MODE.GRAY_LIGHT,
@@ -129,25 +136,28 @@ export function LanguageSelector({ buttonContainerProps }: Props) {
         onClick={onOpen}
         {...buttonContainerProps}
       >
-        <MdOutlineLanguage />
-        <Text
-          ml={2}
-          mr={3}
-          as="span"
-          display={{
-            base: "none",
-            md: "block",
-          }}
-        >
-          {formatMessage(selectedLanguage.message)}
-        </Text>
+        <Flex alignItems="center" justifyContent="center">
+          <MdOutlineLanguage />
+          <Text
+            ml={18}
+            mr={3}
+            as="span"
+            display={{
+              base: "none",
+              md: "block",
+            }}
+          >
+            {formatMessage(selectedLanguage.message)}
+          </Text>
+        </Flex>
+
         <Box
           display={{
             base: "none",
             md: "block",
           }}
         >
-          <FaChevronDown fontSize="0.6em" />
+          <FaChevronRight fontSize="0.6em" />
         </Box>
       </Flex>
       <LanguageSelectorModal isOpen={isOpen} onClose={onClose} />

--- a/renderer/components/NetworkSelector/NetworkSelector.tsx
+++ b/renderer/components/NetworkSelector/NetworkSelector.tsx
@@ -1,0 +1,223 @@
+import {
+  Box,
+  Flex,
+  FlexProps,
+  Heading,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalOverlay,
+  Text,
+  useDisclosure,
+} from "@chakra-ui/react";
+import { useRouter } from "next/router";
+import { useState } from "react";
+import { FaChevronRight } from "react-icons/fa";
+import { MdOutlineLan } from "react-icons/md";
+import { defineMessages, useIntl } from "react-intl";
+
+import { trpcReact } from "@/providers/TRPCProvider";
+import { COLORS } from "@/ui/colors";
+import { Select } from "@/ui/Forms/Select/Select";
+import { PillButton } from "@/ui/PillButton/PillButton";
+
+const messages = defineMessages({
+  mainnet: {
+    defaultMessage: "Mainnet",
+  },
+  testnet: {
+    defaultMessage: "Testnet",
+  },
+  chooseNetwork: {
+    defaultMessage: "Choose the network",
+  },
+  selectNetwork: {
+    defaultMessage: "Select network",
+  },
+  description: {
+    defaultMessage: "The Iron Fish Node App supports {networkCount} networks.",
+  },
+  changeNetwork: {
+    defaultMessage: "Change Network",
+  },
+  changingNetwork: {
+    defaultMessage: "Changing Network",
+  },
+});
+
+const networkOptionsById = {
+  1: {
+    label: "Mainnet",
+    value: "MAINNET",
+  },
+  0: {
+    label: "Testnet",
+    value: "TESTNET",
+  },
+};
+
+const networkOptions = Object.values(networkOptionsById);
+
+const getNetworkById = (id: number) => {
+  if (!(id in networkOptionsById)) {
+    throw new Error(`Invalid network ID ${id} not found.`);
+  }
+  return networkOptionsById[id as keyof typeof networkOptionsById];
+};
+
+type Props = {
+  buttonContainerProps?: FlexProps;
+};
+
+export function NetworkSelector({ buttonContainerProps }: Props) {
+  const { formatMessage } = useIntl();
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const { data } = trpcReact.getStatus.useQuery();
+
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <>
+      <Flex
+        aria-label={formatMessage(messages.selectNetwork)}
+        as="button"
+        borderRadius="5px"
+        bg={COLORS.GRAY_LIGHT}
+        color={COLORS.GRAY_MEDIUM}
+        justifyContent={{
+          base: "center",
+          md: "space-between",
+        }}
+        alignItems="center"
+        py="6px"
+        px={{
+          base: 0,
+          md: "18px",
+        }}
+        _dark={{
+          bg: COLORS.DARK_MODE.GRAY_MEDIUM,
+          color: COLORS.DARK_MODE.GRAY_LIGHT,
+        }}
+        width={{
+          base: "34px",
+          md: "100%",
+        }}
+        height={{
+          base: "34px",
+          md: "100%",
+        }}
+        onClick={onOpen}
+        {...buttonContainerProps}
+      >
+        <Flex alignItems="center" justifyContent="center">
+          <MdOutlineLan />
+          <Text
+            ml={18}
+            mr={3}
+            as="span"
+            display={{
+              base: "none",
+              md: "block",
+            }}
+          >
+            {getNetworkById(data.node.networkId).label}
+          </Text>
+        </Flex>
+        <Box
+          display={{
+            base: "none",
+            md: "block",
+          }}
+        >
+          <FaChevronRight fontSize="0.6em" />
+        </Box>
+      </Flex>
+
+      {data && (
+        <NetworkSelectorModal
+          isOpen={isOpen}
+          onClose={onClose}
+          currentNetwork={data.node.networkId}
+        />
+      )}
+    </>
+  );
+}
+
+function NetworkSelectorModal({
+  isOpen,
+  onClose,
+  currentNetwork,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  currentNetwork: number;
+}) {
+  const router = useRouter();
+  const { mutate: changeNetwork, isLoading: isLoadingChangeNetwork } =
+    trpcReact.changeNetwork.useMutation();
+  const { formatMessage } = useIntl();
+
+  const [selectedNetwork, setSelectedNetwork] = useState(
+    getNetworkById(currentNetwork).value,
+  );
+
+  const hasChanged = getNetworkById(currentNetwork).value !== selectedNetwork;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent maxW="100%" width="600px">
+        <ModalBody px={16} pt={16}>
+          <Heading fontSize="2xl" mb={4}>
+            {formatMessage(messages.chooseNetwork)}
+          </Heading>
+          <Text mb={8}>
+            {formatMessage(messages.description, {
+              networkCount: networkOptions.length,
+            })}
+          </Text>
+
+          <Select
+            onChange={async (e) => {
+              setSelectedNetwork(e.target.value);
+            }}
+            name={"Network Selector"}
+            label="Network"
+            options={networkOptions}
+            value={selectedNetwork}
+          />
+        </ModalBody>
+
+        <ModalFooter display="flex" gap={2} py={8}>
+          <PillButton
+            isDisabled={!hasChanged || isLoadingChangeNetwork}
+            height="60px"
+            px={8}
+            border={0}
+            onClick={() => {
+              changeNetwork(
+                {
+                  network: String(selectedNetwork) as "MAINNET" | "TESTNET",
+                },
+                {
+                  onSuccess: () => {
+                    router.replace("/home");
+                    onClose();
+                  },
+                },
+              );
+            }}
+          >
+            {isLoadingChangeNetwork
+              ? formatMessage(messages.changingNetwork)
+              : formatMessage(messages.changeNetwork)}
+          </PillButton>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/renderer/components/SendAssetsForm/SendAssetsForm.tsx
+++ b/renderer/components/SendAssetsForm/SendAssetsForm.tsx
@@ -1,9 +1,9 @@
-import { VStack, chakra, HStack } from "@chakra-ui/react";
+import { HStack, VStack, chakra } from "@chakra-ui/react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/router";
 import { useEffect, useMemo, useState } from "react";
-import { useForm, Controller } from "react-hook-form";
-import { useIntl, defineMessages } from "react-intl";
+import { Controller, useForm } from "react-hook-form";
+import { defineMessages, useIntl } from "react-intl";
 
 import { TRPCRouterOutputs, trpcReact } from "@/providers/TRPCProvider";
 import { Combobox } from "@/ui/Forms/Combobox/Combobox";
@@ -196,7 +196,7 @@ export function SendAssetsFormContent({
       (account) => account.name === fromAccountValue,
     );
     if (!match) {
-      throw new Error("Non-existent account selected");
+      return accountsData[0];
     }
     return match;
   }, [accountsData, fromAccountValue]);

--- a/renderer/components/TestnetBanner/TestnetBanner.tsx
+++ b/renderer/components/TestnetBanner/TestnetBanner.tsx
@@ -1,0 +1,35 @@
+import { Box, Text } from "@chakra-ui/react";
+import { defineMessages, useIntl } from "react-intl";
+
+import { trpcReact } from "@/providers/TRPCProvider";
+import { COLORS } from "@/ui/colors";
+
+const messages = defineMessages({
+  testnet: {
+    defaultMessage: "You are currently on Testnet!",
+  },
+});
+
+export function TestnetBanner() {
+  const { data } = trpcReact.getStatus.useQuery();
+  const { formatMessage } = useIntl();
+
+  if (data?.node.networkId === 1) {
+    return null;
+  }
+
+  return (
+    <Box
+      bg={COLORS.SKY_BLUE}
+      color={COLORS.DARK_BLUE}
+      _dark={{
+        bg: COLORS.DARK_MODE.DARK_BLUE,
+        color: COLORS.DARK_MODE.SKY_BLUE,
+      }}
+      textAlign="center"
+      p={1}
+    >
+      <Text>{formatMessage(messages.testnet)}</Text>
+    </Box>
+  );
+}

--- a/renderer/intl/locales/en-US.json
+++ b/renderer/intl/locales/en-US.json
@@ -42,6 +42,9 @@
   "2G6Qs7": {
     "message": "Settings saved"
   },
+  "2Ik96T": {
+    "message": "Switch networks"
+  },
   "2KXvZ0": {
     "message": "Are you sure? You can't undo this action afterwards."
   },
@@ -113,6 +116,9 @@
   },
   "6q3tCn": {
     "message": "Connecting"
+  },
+  "711SFa": {
+    "message": "The Iron Fish Node App supports {networkCount} networks."
   },
   "7JxXKc": {
     "message": "Download Snapshot"
@@ -231,6 +237,9 @@
   "HtgUU8": {
     "message": "Type ''{accountName}'' to remove"
   },
+  "Iso3pe": {
+    "message": "Testnet"
+  },
   "IwW0RC": {
     "message": "If none of these steps help, please report the issue on <link>Discord</link>."
   },
@@ -300,6 +309,9 @@
   },
   "NX/nQR": {
     "message": "Changing node settings can optimize performance, improve connectivity, enhance security, and manage resources effectively."
+  },
+  "NZYRdf": {
+    "message": "Mainnet"
   },
   "Nw8+4i": {
     "message": "Peer ID"
@@ -399,6 +411,9 @@
   },
   "UTOugV": {
     "message": "Your Assets"
+  },
+  "Uziuar": {
+    "message": "Change Network"
   },
   "VBDJ/l": {
     "message": "Your balance might not be accurate while you're syncing"
@@ -568,6 +583,9 @@
   "kTt/ND": {
     "message": "Russian"
   },
+  "lhnRYP": {
+    "message": "Choose the network"
+  },
   "lu5YPq": {
     "message": "unknown asset"
   },
@@ -622,6 +640,9 @@
   "qkf/DE": {
     "message": "Cancel Transaction"
   },
+  "qtSDFj": {
+    "message": "You are currently on Testnet!"
+  },
   "r1Z23X": {
     "message": "All your accounts will be displayed in this section. To create or import an account, simply click one of the buttons above."
   },
@@ -666,6 +687,12 @@
   },
   "vaP4MI": {
     "message": "It currently holds:"
+  },
+  "vysmK2": {
+    "message": "Select network"
+  },
+  "w2FJVr": {
+    "message": "Changing Network"
   },
   "wGpbja": {
     "message": "Add Contact Error"

--- a/renderer/layouts/MainLayout.tsx
+++ b/renderer/layouts/MainLayout.tsx
@@ -1,11 +1,11 @@
 import {
+  Box,
+  Flex,
   Grid,
   GridItem,
-  Box,
-  VStack,
-  HStack,
-  Flex,
   Heading,
+  HStack,
+  VStack,
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import { createContext, ReactNode, useContext, useState } from "react";
@@ -13,7 +13,9 @@ import { defineMessages, useIntl } from "react-intl";
 
 import { BackButton } from "@/components/BackButton/BackButton";
 import { LanguageSelector } from "@/components/LanguageSelector/LanguageSelector";
+import { NetworkSelector } from "@/components/NetworkSelector/NetworkSelector";
 import { StatusIndicator } from "@/components/StatusIndicator/StatusIndicator";
+import { TestnetBanner } from "@/components/TestnetBanner/TestnetBanner";
 import { ChakraLink } from "@/ui/ChakraLink/ChakraLink";
 import { COLORS } from "@/ui/colors";
 import { DarkModeSwitch } from "@/ui/DarkModeSwitch/DarkModeSwitch";
@@ -167,6 +169,7 @@ function Sidebar() {
       </VStack>
       <VStack alignItems="center" gap={4}>
         <StatusIndicator />
+        <NetworkSelector />
         <LanguageSelector />
         <DarkModeSwitch />
       </VStack>
@@ -200,51 +203,58 @@ export default function MainLayout({ children, backLinkProps }: Props) {
         bg: COLORS.DARK_MODE.BG,
       }}
     >
-      <Grid height="100%" templateColumns="auto 1fr">
-        <GridItem
-          h="100%"
-          overflow="auto"
-          w={{
-            base: "auto",
-            md: "265px",
-          }}
-          px={4}
-          pt="50px"
-          pb={{
-            base: 8,
-            md: 6,
-          }}
-          display="flex"
-          alignItems="stretch"
-        >
-          <Sidebar />
+      <Grid height="100%" templateRows="auto 1fr" templateColumns="1fr" gap={0}>
+        <GridItem>
+          <TestnetBanner />
         </GridItem>
-        <GridItem
-          px={6}
-          pt={10}
-          pb={8}
-          h="100%"
-          overflow="auto"
-          ref={(r) => setScrollElement(r)}
-        >
-          <ScrollElementContext.Provider value={scrollElement}>
-            <Box
-              mx="auto"
-              maxWidth={{
-                base: "100%",
-                xl: "1048px",
-                "2xl": "1280px",
+        <GridItem>
+          <Grid height="100%" templateColumns="auto 1fr">
+            <GridItem
+              h="100%"
+              overflow="auto"
+              w={{
+                base: "auto",
+                md: "265px",
               }}
+              px={4}
+              pt="50px"
+              pb={{
+                base: 8,
+                md: 6,
+              }}
+              display="flex"
+              alignItems="stretch"
             >
-              {backLinkProps && (
-                <BackButton
-                  href={backLinkProps.href}
-                  label={backLinkProps.label}
-                />
-              )}
-              {children}
-            </Box>
-          </ScrollElementContext.Provider>
+              <Sidebar />
+            </GridItem>
+            <GridItem
+              px={6}
+              pt={10}
+              pb={8}
+              h="100%"
+              overflow="auto"
+              ref={(r) => setScrollElement(r)}
+            >
+              <ScrollElementContext.Provider value={scrollElement}>
+                <Box
+                  mx="auto"
+                  maxWidth={{
+                    base: "100%",
+                    xl: "1048px",
+                    "2xl": "1280px",
+                  }}
+                >
+                  {backLinkProps && (
+                    <BackButton
+                      href={backLinkProps.href}
+                      label={backLinkProps.label}
+                    />
+                  )}
+                  {children}
+                </Box>
+              </ScrollElementContext.Provider>
+            </GridItem>
+          </Grid>
         </GridItem>
       </Grid>
     </WithDraggableArea>

--- a/renderer/layouts/OnboardingLayout.tsx
+++ b/renderer/layouts/OnboardingLayout.tsx
@@ -12,6 +12,7 @@ import { ReactNode } from "react";
 import { defineMessages, useIntl } from "react-intl";
 
 import { LanguageSelector } from "@/components/LanguageSelector/LanguageSelector";
+import { NetworkSelector } from "@/components/NetworkSelector/NetworkSelector";
 import bigOnboardingFish from "@/images/big-onboarding-fish.svg";
 import discord from "@/images/discord.png";
 
@@ -94,6 +95,17 @@ export function OnboardingLayout({ children }: { children: ReactNode }) {
           >
             <Box>
               <LanguageSelector
+                buttonContainerProps={{
+                  px: {
+                    base: 0,
+                    md: 4,
+                  },
+                  bg: "white",
+                }}
+              />
+            </Box>
+            <Box>
+              <NetworkSelector
                 buttonContainerProps={{
                   px: {
                     base: 0,

--- a/renderer/pages/accounts/index.tsx
+++ b/renderer/pages/accounts/index.tsx
@@ -29,6 +29,9 @@ const messages = defineMessages({
   accountsHeader: {
     defaultMessage: "Accounts",
   },
+  switchNetworks: {
+    defaultMessage: "Switch networks",
+  },
   createAccount: {
     defaultMessage: "Create",
   },

--- a/renderer/pages/home.tsx
+++ b/renderer/pages/home.tsx
@@ -1,6 +1,6 @@
-import { VStack, Flex, Spinner } from "@chakra-ui/react";
+import { Flex, Spinner, VStack } from "@chakra-ui/react";
 import { useRouter } from "next/router";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { trpcReact } from "@/providers/TRPCProvider";
 import { LogoLg } from "@/ui/SVGs/LogoLg";
@@ -11,11 +11,21 @@ import { LogoLg } from "@/ui/SVGs/LogoLg";
  */
 export default function Home() {
   const router = useRouter();
+
+  const [randomValue] = useState(() => {
+    return Math.random();
+  });
+
   const { data: initialStateData, isLoading: isInitialStateLoading } =
-    trpcReact.getInitialState.useQuery(undefined, {
-      retry: false,
-      useErrorBoundary: true,
-    });
+    trpcReact.getInitialState.useQuery(
+      {
+        seed: randomValue.toString(),
+      },
+      {
+        retry: false,
+        useErrorBoundary: true,
+      },
+    );
 
   const { mutate: startNode } = trpcReact.startNode.useMutation();
 

--- a/renderer/pages/home.tsx
+++ b/renderer/pages/home.tsx
@@ -12,6 +12,7 @@ import { LogoLg } from "@/ui/SVGs/LogoLg";
 export default function Home() {
   const router = useRouter();
 
+  // We use this random value to ensure that the useQuery hook doesn't cache the result
   const [randomValue] = useState(() => {
     return Math.random();
   });

--- a/renderer/ui/colors.ts
+++ b/renderer/ui/colors.ts
@@ -9,6 +9,9 @@ export const COLORS = {
   DEEP_BLUE: "#1D0070",
   RED: "#F15929",
 
+  SKY_BLUE: "#D3F9FF",
+  DARK_BLUE: "#005664",
+
   GREEN_LIGHT: "#ECFFCE",
   GREEN_DARK: "#6A991C",
   YELLOW_LIGHT: "#FFF9B8",
@@ -21,6 +24,8 @@ export const COLORS = {
     GRAY_LIGHT: "#ADAEB4",
     GRAY_MEDIUM: "#3B3B3B",
     GRAY_DARK: "#252525",
+    SKY_BLUE: "#D3F9FF",
+    DARK_BLUE: "#005664",
     GREEN_LIGHT: "#C7F182",
     GREEN_DARK: "#242C18",
     YELLOW_LIGHT: "#E3DB7C",


### PR DESCRIPTION
Ability to switch networks from mainnet to testnet
- New component to add a banner when on testnet
- Styling changes to the network selector and language selector
- Redirects user to home when the network is switched to download snapshot or create an account

Figma: https://www.figma.com/file/fYw3aNgfS0qCS2jezGqv8P/Node-App-(New-Ui-Kit)?type=design&node-id=7785-3417&mode=design&t=AuNLp2QtvepagYNl-0