### PR TITLE
Change key in accounts list to name instead of address

### DIFF
--- a/renderer/components/UserAccountsList/UserAccountsList.tsx
+++ b/renderer/components/UserAccountsList/UserAccountsList.tsx
@@ -150,7 +150,7 @@ export function UserAccountsList() {
         .map((account) => {
           return (
             <AccountRow
-              key={account.address}
+              key={account.name}
               color={getGradientColor(account.address)}
               name={account.name}
               balance={account.balances.iron.confirmed}


### PR DESCRIPTION
Not really sure what the proper key is here, but accounts should be unique by name, enforced by the wallet, but it's definitely now possible to add multiple accounts with the same public address due to multisig. I don't think this makes too much of a difference either way, I was just seeing key-related logs in the console.
