### PR TITLE
Display change notes differently in transaction view

### DIFF
--- a/renderer/components/NoteRow/NoteHeadings.tsx
+++ b/renderer/components/NoteRow/NoteHeadings.tsx
@@ -2,7 +2,11 @@ import { Grid, GridItem, Text } from "@chakra-ui/react";
 
 import { CARET_WIDTH, useHeadingsText } from "./shared";
 
-export function NoteHeadings() {
+type Props = {
+  asTransactions?: boolean;
+};
+
+export function NoteHeadings({ asTransactions }: Props) {
   const headingsText = useHeadingsText();
 
   return (
@@ -13,7 +17,7 @@ export function NoteHeadings() {
       }}
       templateColumns={{
         base: `repeat(5, 1fr)`,
-        lg: `repeat(5, 1fr) ${CARET_WIDTH}`,
+        lg: `repeat(5, 1fr) ${asTransactions ? CARET_WIDTH : ""}`,
       }}
       opacity="0.8"
       mb={4}

--- a/renderer/components/NoteRow/NoteRow.tsx
+++ b/renderer/components/NoteRow/NoteRow.tsx
@@ -11,6 +11,7 @@ import { formatDate } from "@/utils/formatDate";
 import { hexToUTF16String } from "@/utils/hexToUTF16String";
 import { formatOre } from "@/utils/ironUtils";
 
+import { ChangeIcon } from "./icons/ChangeIcon";
 import { ExpiredIcon } from "./icons/ExpiredIcon";
 import { PendingIcon } from "./icons/PendingIcon";
 import { ReceivedIcon } from "./icons/ReceivedIcon";
@@ -22,24 +23,35 @@ function getNoteStatusDisplay(
   type: TransactionType,
   status: TransactionStatus,
   asTransaction: boolean,
+  isSelfSend: boolean,
 ): { icon: ReactNode; message: MessageDescriptor } {
   if (!asTransaction || status === "confirmed") {
+    if (isSelfSend) {
+      return { icon: <ChangeIcon />, message: messages.change };
+    }
+
     if (type === "send") {
       return { icon: <SentIcon />, message: messages.sent };
-    } else if (type === "receive" || type === "miner") {
+    }
+
+    if (type === "receive" || type === "miner") {
       return { icon: <ReceivedIcon />, message: messages.received };
     }
 
     const unhandledType: never = type;
     console.error("Unhandled transaction type", unhandledType);
     return { icon: <ReceivedIcon />, message: messages.received };
-  } else if (
+  }
+
+  if (
     status === "pending" ||
     status === "unknown" ||
     status === "unconfirmed"
   ) {
     return { icon: <PendingIcon />, message: messages.pending };
-  } else if (status === "expired") {
+  }
+
+  if (status === "expired") {
     return { icon: <ExpiredIcon />, message: messages.expired };
   }
 
@@ -102,7 +114,14 @@ export function NoteRow({
   asTransaction?: boolean;
 }) {
   const { formatMessage } = useIntl();
-  const statusDisplay = getNoteStatusDisplay(type, status, asTransaction);
+
+  const isSelfSend = from === to;
+  const statusDisplay = getNoteStatusDisplay(
+    type,
+    status,
+    asTransaction,
+    isSelfSend,
+  );
   const headings = useHeadingsText();
 
   const cellContent = useMemo(() => {

--- a/renderer/components/NoteRow/icons/ChangeIcon.tsx
+++ b/renderer/components/NoteRow/icons/ChangeIcon.tsx
@@ -1,0 +1,25 @@
+import { chakra, useColorModeValue } from "@chakra-ui/react";
+
+import { COLORS } from "@/ui/colors";
+
+export function ChangeIcon() {
+  const fill = useColorModeValue(
+    COLORS.GRAY_MEDIUM,
+    COLORS.DARK_MODE.GRAY_LIGHT,
+  );
+
+  return (
+    <chakra.svg
+      width={26}
+      height={26}
+      fill="none"
+      color={COLORS.GRAY_LIGHT}
+      _dark={{
+        color: COLORS.DARK_MODE.GRAY_MEDIUM,
+      }}
+    >
+      <circle cx={13} cy={13} r={13} fill="currentColor" />
+      <path stroke={fill} strokeWidth={1.5} d="M14.5 17H9v-5.5M9 17l8-8" />
+    </chakra.svg>
+  );
+}

--- a/renderer/components/NoteRow/shared.ts
+++ b/renderer/components/NoteRow/shared.ts
@@ -36,6 +36,11 @@ export const messages = defineMessages({
   multipleMemos: {
     defaultMessage: "Multiple memos",
   },
+  change: {
+    defaultMessage: "Change",
+    description:
+      "Change as in the money that is returned to the sender after a transaction",
+  },
 });
 
 export function useHeadingsText() {

--- a/renderer/components/NotesList/NotesList.tsx
+++ b/renderer/components/NotesList/NotesList.tsx
@@ -72,7 +72,7 @@ export function NotesList({
       <Heading as="h2" fontSize="2xl" mb={8}>
         {heading}
       </Heading>
-      <NoteHeadings />
+      <NoteHeadings asTransactions={asTransactions} />
       {isLoading && <Skeleton height="600px" />}
       {!isLoading && customScrollElement && (
         <Virtuoso

--- a/renderer/components/TransactionInformation/TransactionInformation.tsx
+++ b/renderer/components/TransactionInformation/TransactionInformation.tsx
@@ -158,7 +158,7 @@ export function TransactionInformation({ transaction, ...rest }: Props) {
                   >
                     {formatMessage(label)}
                   </Text>
-                  <Text fontSize="md">{render(transaction)}</Text>
+                  <Box fontSize="md">{render(transaction)}</Box>
                 </VStack>
                 {icon}
               </HStack>

--- a/renderer/intl/locales/en-US.json
+++ b/renderer/intl/locales/en-US.json
@@ -249,6 +249,10 @@
   "K3r6DQ": {
     "message": "Delete"
   },
+  "KGELcL": {
+    "description": "Change as in the money that is returned to the sender after a transaction",
+    "message": "Change"
+  },
   "KN7zKn": {
     "message": "Error"
   },


### PR DESCRIPTION
- Separates self-sends from other notes and puts them in "Change" section
- Fixes UI issue where headings weren't lining up

![image](https://github.com/iron-fish/ironfish-node-app/assets/3639170/b6e7aa29-8fc1-4542-b550-2a5f62c52cb9)
![image](https://github.com/iron-fish/ironfish-node-app/assets/3639170/677d46ab-f54b-46a5-ac51-eaeb7954dbe0)
