### PR TITLE
Skip snapshot step in onboarding if not stale

### DIFF
--- a/main/api/ironfish/index.ts
+++ b/main/api/ironfish/index.ts
@@ -80,6 +80,9 @@ export const ironfishRouter = t.router({
   getInitialState: t.procedure.query(async () => {
     return manager.getInitialState();
   }),
+  shouldDownloadSnapshot: t.procedure.query(async () => {
+    return manager.shouldDownloadSnapshot();
+  }),
   getExplorerUrl: t.procedure.input(getExplorerUrlInput).query(async (opts) => {
     const ironfish = await manager.getIronfish();
     const rpcClient = await ironfish.rpcClient();

--- a/main/api/manager.ts
+++ b/main/api/manager.ts
@@ -24,7 +24,7 @@ export class Manager {
   async shouldDownloadSnapshot(): Promise<boolean> {
     const ironfish = await this.getIronfish();
     const rpcClient = await ironfish.rpcClient();
-    return this.isSnapshotStale(rpcClient);
+    return await this.isSnapshotStale(rpcClient);
   }
 
   private isSnapshotStale = async (rpcClient: RpcClient) => {

--- a/renderer/components/OnboardingFlow/TelemetryPrompt/TelemetryPrompt.tsx
+++ b/renderer/components/OnboardingFlow/TelemetryPrompt/TelemetryPrompt.tsx
@@ -1,11 +1,11 @@
 import {
-  Text,
   Box,
-  Heading,
   FormControl,
-  Switch,
   FormLabel,
   HStack,
+  Heading,
+  Switch,
+  Text,
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import { useCallback } from "react";
@@ -40,6 +40,10 @@ export function TelemetryPrompt() {
   const { data: configData } = trpcReact.getConfig.useQuery({
     name: "enableTelemetry",
   });
+  const { mutate: startNode } = trpcReact.startNode.useMutation();
+  const { data: shouldDownloadSnapshotData } =
+    trpcReact.shouldDownloadSnapshot.useQuery();
+
   const { mutate: setConfig } = trpcReact.setConfig.useMutation();
   const { formatMessage } = useIntl();
 
@@ -87,7 +91,12 @@ export function TelemetryPrompt() {
           height="60px"
           px={8}
           onClick={() => {
-            router.push("/onboarding/snapshot-download");
+            if (shouldDownloadSnapshotData) {
+              router.push("/onboarding/snapshot-download");
+            } else {
+              startNode();
+              router.replace("/accounts");
+            }
           }}
         >
           {formatMessage(messages.continue)}

--- a/renderer/components/OnboardingFlow/TelemetryPrompt/TelemetryPrompt.tsx
+++ b/renderer/components/OnboardingFlow/TelemetryPrompt/TelemetryPrompt.tsx
@@ -41,7 +41,7 @@ export function TelemetryPrompt() {
     name: "enableTelemetry",
   });
   const { mutate: startNode } = trpcReact.startNode.useMutation();
-  const { data: shouldDownloadSnapshotData } =
+  const { data: shouldDownloadSnapshotData, isLoading } =
     trpcReact.shouldDownloadSnapshot.useQuery();
 
   const { mutate: setConfig } = trpcReact.setConfig.useMutation();
@@ -90,6 +90,7 @@ export function TelemetryPrompt() {
         <PillButton
           height="60px"
           px={8}
+          isDisabled={isLoading}
           onClick={() => {
             if (shouldDownloadSnapshotData) {
               router.push("/onboarding/snapshot-download");


### PR DESCRIPTION
Edgecase: When the user deletes all accounts and is prompted to create an account again when re-opening the app the next time. This will also be useful when switching networks (coming soon)