### PR TITLE
Temporary fix to unblock users for error when downloading snapshot

### DIFF
--- a/renderer/layouts/OnboardingLayout.tsx
+++ b/renderer/layouts/OnboardingLayout.tsx
@@ -12,7 +12,6 @@ import { ReactNode } from "react";
 import { defineMessages, useIntl } from "react-intl";
 
 import { LanguageSelector } from "@/components/LanguageSelector/LanguageSelector";
-import { NetworkSelector } from "@/components/NetworkSelector/NetworkSelector";
 import bigOnboardingFish from "@/images/big-onboarding-fish.svg";
 import discord from "@/images/discord.png";
 
@@ -104,7 +103,7 @@ export function OnboardingLayout({ children }: { children: ReactNode }) {
                 }}
               />
             </Box>
-            <Box>
+            {/* <Box>
               <NetworkSelector
                 buttonContainerProps={{
                   px: {
@@ -114,7 +113,7 @@ export function OnboardingLayout({ children }: { children: ReactNode }) {
                   bg: "white",
                 }}
               />
-            </Box>
+            </Box> */}
             <Box
               as="a"
               target="_blank"


### PR DESCRIPTION
- My suspicion is that electron doens't handle making an API call to the node when the snapshot is being downloaded.
- This API call happens to determine the network id of the node.