### PR TITLE
Get current network from getNetworkInfo instead of node.getStatus

### DIFF
--- a/main/api/ironfish/index.ts
+++ b/main/api/ironfish/index.ts
@@ -125,6 +125,12 @@ export const ironfishRouter = t.router({
     const ironfish = await manager.getIronfish();
     await ironfish.start();
   }),
+  getNetworkInfo: t.procedure.query(async () => {
+    const ironfish = await manager.getIronfish();
+    const rpcClient = await ironfish.rpcClient();
+    const response = await rpcClient.chain.getNetworkInfo();
+    return response.content;
+  }),
   changeNetwork: t.procedure
     .input(
       z.object({

--- a/renderer/components/NetworkSelector/NetworkSelector.tsx
+++ b/renderer/components/NetworkSelector/NetworkSelector.tsx
@@ -73,7 +73,7 @@ type Props = {
 export function NetworkSelector({ buttonContainerProps }: Props) {
   const { formatMessage } = useIntl();
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const { data } = trpcReact.getStatus.useQuery();
+  const { data } = trpcReact.getNetworkInfo.useQuery();
 
   if (!data) {
     return null;
@@ -123,7 +123,7 @@ export function NetworkSelector({ buttonContainerProps }: Props) {
               md: "block",
             }}
           >
-            {getNetworkById(data.node.networkId).label}
+            {getNetworkById(data.networkId).label}
           </Text>
         </Flex>
         <Box
@@ -140,7 +140,7 @@ export function NetworkSelector({ buttonContainerProps }: Props) {
         <NetworkSelectorModal
           isOpen={isOpen}
           onClose={onClose}
-          currentNetwork={data.node.networkId}
+          currentNetwork={data.networkId}
         />
       )}
     </>

--- a/renderer/components/TestnetBanner/TestnetBanner.tsx
+++ b/renderer/components/TestnetBanner/TestnetBanner.tsx
@@ -11,10 +11,10 @@ const messages = defineMessages({
 });
 
 export function TestnetBanner() {
-  const { data } = trpcReact.getStatus.useQuery();
+  const { data } = trpcReact.getNetworkInfo.useQuery();
   const { formatMessage } = useIntl();
 
-  if (data?.node.networkId === 1) {
+  if (data?.networkId === 1) {
     return null;
   }
 

--- a/renderer/layouts/OnboardingLayout.tsx
+++ b/renderer/layouts/OnboardingLayout.tsx
@@ -12,6 +12,7 @@ import { ReactNode } from "react";
 import { defineMessages, useIntl } from "react-intl";
 
 import { LanguageSelector } from "@/components/LanguageSelector/LanguageSelector";
+import { NetworkSelector } from "@/components/NetworkSelector/NetworkSelector";
 import bigOnboardingFish from "@/images/big-onboarding-fish.svg";
 import discord from "@/images/discord.png";
 
@@ -103,7 +104,7 @@ export function OnboardingLayout({ children }: { children: ReactNode }) {
                 }}
               />
             </Box>
-            {/* <Box>
+            <Box>
               <NetworkSelector
                 buttonContainerProps={{
                   px: {
@@ -113,7 +114,7 @@ export function OnboardingLayout({ children }: { children: ReactNode }) {
                   bg: "white",
                 }}
               />
-            </Box> */}
+            </Box>
             <Box
               as="a"
               target="_blank"


### PR DESCRIPTION
Calling node.getStatus when the node is not running throws an unhandled exception that is currently being investigated. This PR changes the network call to use getNetworkInfo instead of node.getStatus to avoid the exception.

Adds the network selector back to the onboarding layout