### PR TITLE
Fix builds on macos GitHub Actions runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -163,6 +163,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
+      - name: Install Python setuptools
+        run: brew install python-setuptools
       - name: Install dependencies
         run: npm install
       - name: Setup code signing


### PR DESCRIPTION
This should fix the broken build for the macos GitHub Actions runner.

We saw this same issue in the mobile wallet builds: https://github.com/iron-fish/mobile-wallet/pull/21/files#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1
