### PR TITLE
Remove reload and force reload from menus

### DIFF
--- a/main/background.ts
+++ b/main/background.ts
@@ -91,10 +91,16 @@ function setAppMenu() {
   for (const menuItem of defaultMenu.items) {
     const newSubmenu = new Menu();
 
-    // @ts-expect-error subMenuItem.role should be forcereload instead of forceReload
     const filteredMenu =
       menuItem.submenu?.items.filter(
         (subMenuItem) =>
+          // We want to prevent the window from being reloaded since our dynamic routes aren't statically
+          // generated. This causes the app to 404 if the user reloads on a dynamic route. We tried calling
+          // preventDefault in beforeunload in the app and explicitly called window.destroy() in the window.close
+          // event on the main process, but that caused a crash in electron-trpc when closing the app while a TRPC
+          // subscription was active. Removing reload and forcereload also disables their keybindings, so it
+          // should prevent users from reloading the app.
+          // @ts-expect-error subMenuItem.role should be forcereload instead of forceReload
           subMenuItem.role != "reload" && subMenuItem.role != "forcereload",
       ) ?? [];
     for (const subMenuItem of filteredMenu) {

--- a/main/main-window.ts
+++ b/main/main-window.ts
@@ -140,12 +140,6 @@ class MainWindow {
       return { action: "deny" };
     });
 
-    // We're intentially preventing the browser from handling unload events (e.g. close, refresh)
-    // so we have to handle closing the window manually.
-    this.window.on("close", () => {
-      this.window?.destroy();
-    });
-
     this.window.on("closed", () => {
       this.window = null;
       const [promise, resolve] = PromiseUtils.split<BrowserWindow>();

--- a/renderer/pages/_app.tsx
+++ b/renderer/pages/_app.tsx
@@ -1,7 +1,6 @@
 import { ChakraProvider } from "@chakra-ui/react";
 import { AppProps } from "next/app";
 import Head from "next/head";
-import { useEffect } from "react";
 import { useIsClient } from "usehooks-ts";
 
 import { ErrorBoundary } from "@/components/ErrorBoundary/ErrorBoundary";
@@ -51,17 +50,6 @@ const systemColorModeManager = new SystemColorModeManager();
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   const isClient = useIsClient();
-
-  useEffect(() => {
-    // Prevent window from unloading (i.e. closing or being reloaded). This is due to dynamic routes not
-    // being statically generated, which causes the app to 404 if the user reloads on a dynamic route.
-    // Closing the window is handled by the main process, which listens for the "close" event and destroys
-    // the window.
-    window.addEventListener("beforeunload", (e) => {
-      e.preventDefault();
-      e.returnValue = true;
-    });
-  }, []);
 
   if (!isClient) {
     return null;


### PR DESCRIPTION
Removes Reload and Force Reload from the app menu, which also removes the keyboard shortcuts for reloading and force reloading.

Our previous solution intercepted the beforeunload event and manually called destroy on the window in the `close` event. However, this causes issues with electron-trpc handling the detachWindow event, since it assumes the window won't be destroyed when calling its internal `detachWindow`. One example of that is here: #192

I'll try to put up a PR to electron-trpc to improve their detachWindow handler, but in the meantime, this seems to solve both disabling reloading and solve the crashing on exit when a subscription is active.

Fixes IFL-2504