### PR TITLE
Remove unnecessary detachWindow call

### DIFF
--- a/main/background.ts
+++ b/main/background.ts
@@ -32,10 +32,6 @@ async function createWindow(handler: ReturnType<typeof createIPCHandler>) {
     window.maximize();
   });
 
-  window.once("closed", () => {
-    handler.detachWindow(window);
-  });
-
   if (isProd) {
     await window.loadURL("app://./home");
   } else {


### PR DESCRIPTION
We don't need to call `detachWindow` explicitly, since it's already called by electron-trpc already here: https://github.com/jsonnull/electron-trpc/blob/cfdb2e58126deb5867d57e21b5aac1d96ef49b44/packages/electron-trpc/src/main/createIPCHandler.ts#L93-L96

