### PR TITLE
Bump Electron to v29.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "date-fns": "^2.30.0",
         "date-fns-tz": "^2.0.0",
         "dotenv": "^16.3.1",
-        "electron": "28.1.4",
+        "electron": "29.4.2",
         "electron-builder": "^24.6.4",
         "electron-log": "5.0.0",
         "electron-store": "^8.1.0",
@@ -8850,14 +8850,14 @@
       }
     },
     "node_modules/electron": {
-      "version": "28.1.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-28.1.4.tgz",
-      "integrity": "sha512-WE6go611KOhtH6efRPMnVC7FE7DCKnQ3ZyHFeI1DbaCy8OU4UjZ8/CZGcuZmZgRdxSBEHoHdgaJkWRHZzF0FOg==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-29.4.2.tgz",
+      "integrity": "sha512-XyIkuWQguwY8hGtLg0j5Q4Fqphdbh0ctBsKCSVzJ/R7Z2+2WN/oQ1M+zYwchmfiDgiuL3EKkrBrfPdxXYdMr+A==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^18.11.18",
+        "@types/node": "^20.9.0",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -9093,6 +9093,15 @@
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "20.12.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.13.tgz",
+      "integrity": "sha512-gBGeanV41c1L171rR7wjbMiEpEI/l5XFQdLLfhr/REwpgDy/4U8y89+i8kRiLzDyZdOkXh+cRaTetUnCYutoXA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "date-fns": "^2.30.0",
     "date-fns-tz": "^2.0.0",
     "dotenv": "^16.3.1",
-    "electron": "28.1.4",
+    "electron": "29.4.2",
     "electron-builder": "^24.6.4",
     "electron-log": "5.0.0",
     "electron-store": "^8.1.0",


### PR DESCRIPTION
Bumps the Electron version to v29.4.2. Notably, this now means the main process uses Node.js 20 instead of 18!
