### PR TITLE
Fix asset verification checkmark always displaying

### DIFF
--- a/renderer/components/AccountAssets/AccountAssets.tsx
+++ b/renderer/components/AccountAssets/AccountAssets.tsx
@@ -176,7 +176,9 @@ export function AccountAssets({ accountName }: { accountName: string }) {
                         borderRadius="4px"
                       >
                         <Text fontSize="lg" flexGrow={1} as="span">
-                          {balance.asset.verification ? "✔ " : ""}
+                          {balance.asset.verification.status === "verified"
+                            ? "✔ "
+                            : ""}
                           {CurrencyUtils.shortSymbol(assetId, asset)}
                         </Text>
                         <Text fontSize="lg">{majorString}</Text>


### PR DESCRIPTION
The asset verification checkmark is displaying for all custom assets because we're not checking against the verification status field. Updates the check to only show the checkmark if the asset is verified.
