### PR TITLE
adds transaction hash to accounts overview page

### DIFF
--- a/renderer/components/AccountRow/AccountRow.tsx
+++ b/renderer/components/AccountRow/AccountRow.tsx
@@ -22,7 +22,7 @@ import { LogoSm } from "@/ui/SVGs/LogoSm";
 import { formatOre } from "@/utils/ironUtils";
 
 import { AccountSyncingProgress } from "../AccountSyncingProgress/AccountSyncingProgress";
-import { CopyAddress } from "../CopyAddress/CopyAddress";
+import { CopyToClipboard } from "../CopyToClipboard/CopyToClipboard";
 import { LedgerChip } from "../LedgerChip/LedgerChip";
 import { ViewOnlyChip } from "../ViewOnlyChip/ViewOnlyChip";
 
@@ -112,7 +112,7 @@ export function AccountRow({
               <Heading as="span" fontWeight="regular" fontSize="2xl">
                 {formatOre(balance)} $IRON
               </Heading>
-              <CopyAddress address={address} />
+              <CopyToClipboard text={address} />
             </VStack>
 
             <VStack
@@ -125,8 +125,8 @@ export function AccountRow({
                   !isAccountSendEligible
                     ? formatMessage(messages.viewOnlySendDisabled)
                     : !isSynced.synced
-                    ? formatMessage(messages.syncingSendDisabled)
-                    : null
+                      ? formatMessage(messages.syncingSendDisabled)
+                      : null
                 }
                 placement="top"
               >

--- a/renderer/components/BridgeTransactionInformation/BridgeTransactionInformationShell.tsx
+++ b/renderer/components/BridgeTransactionInformation/BridgeTransactionInformationShell.tsx
@@ -4,10 +4,10 @@ import {
   Grid,
   GridItem,
   Heading,
-  Text,
   HStack,
-  VStack,
   Image,
+  Text,
+  VStack,
 } from "@chakra-ui/react";
 import NextImage from "next/image";
 import { ReactNode } from "react";
@@ -17,7 +17,7 @@ import chainportIcon from "@/images/chainport/chainport-icon-lg.png";
 import { COLORS } from "@/ui/colors";
 import { ShadowCard } from "@/ui/ShadowCard/ShadowCard";
 
-import { CopyAddress } from "../CopyAddress/CopyAddress";
+import { CopyToClipboard } from "../CopyToClipboard/CopyToClipboard";
 
 const messages = defineMessages({
   heading: {
@@ -171,11 +171,12 @@ export function BridgeTransactionInformationShell({
                   <Box fontSize="md">
                     <VStack alignItems="flex-start">
                       {targetTxHash ? (
-                        <CopyAddress
+                        <CopyToClipboard
                           fontSize="md"
                           color={COLORS.BLACK}
                           _dark={{ color: COLORS.WHITE }}
-                          address={targetTxHash}
+                          text={targetTxHash}
+                          messageType="hashCopied"
                           parts={2}
                         />
                       ) : (

--- a/renderer/components/ContactRow/ContactRow.tsx
+++ b/renderer/components/ContactRow/ContactRow.tsx
@@ -9,7 +9,7 @@ import { PillButton } from "@/ui/PillButton/PillButton";
 import { ShadowCard } from "@/ui/ShadowCard/ShadowCard";
 import { ArrowSend } from "@/ui/SVGs/ArrowSend";
 
-import { CopyAddress } from "../CopyAddress/CopyAddress";
+import { CopyToClipboard } from "../CopyToClipboard/CopyToClipboard";
 import { FishIcon } from "../FishIcon/FishIcon";
 
 const messages = defineMessages({
@@ -78,7 +78,7 @@ export function ContactRow({ name, address, order }: Props) {
             <Text as="span">{name}</Text>
           </GridItem>
           <GridItem display="flex">
-            <CopyAddress address={address} color="inherit" />
+            <CopyToClipboard text={address} color="inherit" />
           </GridItem>
           <GridItem display="flex" alignItems="center" mr={4}>
             <PillButton

--- a/renderer/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/renderer/components/CopyToClipboard/CopyToClipboard.tsx
@@ -11,18 +11,26 @@ const messages = defineMessages({
   addressCopied: {
     defaultMessage: "Address copied to clipboard",
   },
+  hashCopied: {
+    defaultMessage: "Hash copied to clipboard",
+  },
+  default: {
+    defaultMessage: "Copied to clipboard",
+  },
 });
 
 type Props = TextProps & {
-  address: string;
+  text: string;
   parts?: 2 | 3;
   truncate?: boolean;
+  messageType?: keyof typeof messages;
 };
 
-export function CopyAddress({
-  address,
+export function CopyToClipboard({
+  text,
   parts = 3,
   truncate = true,
+  messageType = "addressCopied",
   ...rest
 }: Props) {
   const [_, copyToClipboard] = useCopyToClipboard();
@@ -34,9 +42,9 @@ export function CopyAddress({
       as="button"
       onClick={(e) => {
         e.preventDefault();
-        copyToClipboard(address);
+        copyToClipboard(text);
         toast({
-          message: formatMessage(messages.addressCopied),
+          message: formatMessage(messages[messageType]),
         });
       }}
       color={COLORS.GRAY_MEDIUM}
@@ -48,7 +56,7 @@ export function CopyAddress({
       }}
       {...rest}
     >
-      {truncate ? truncateString(address, parts) : address}
+      {truncate ? truncateString(text, parts) : text}
       <CopyIcon
         color={COLORS.GRAY_MEDIUM}
         _dark={{ color: COLORS.DARK_MODE.GRAY_LIGHT }}

--- a/renderer/components/NoteRow/NoteHeadings.tsx
+++ b/renderer/components/NoteRow/NoteHeadings.tsx
@@ -7,7 +7,7 @@ type Props = {
 };
 
 export function NoteHeadings({ asTransactions }: Props) {
-  const headingsText = useHeadingsText();
+  const headingsText = useHeadingsText(asTransactions);
 
   return (
     <Grid
@@ -16,8 +16,10 @@ export function NoteHeadings({ asTransactions }: Props) {
         lg: "grid",
       }}
       templateColumns={{
-        base: `repeat(5, 1fr)`,
-        lg: `repeat(5, 1fr) ${asTransactions ? CARET_WIDTH : ""}`,
+        base: `repeat(${asTransactions ? "6" : "5"}, 1fr)`,
+        lg: `repeat(${asTransactions ? "6" : "5"}, 1fr) ${
+          asTransactions ? CARET_WIDTH : ""
+        }`,
       }}
       opacity="0.8"
       mb={4}

--- a/renderer/components/NoteRow/NoteRow.tsx
+++ b/renderer/components/NoteRow/NoteRow.tsx
@@ -1,5 +1,5 @@
 import { ChevronRightIcon } from "@chakra-ui/icons";
-import { Box, HStack, Text, Flex } from "@chakra-ui/react";
+import { Box, Flex, HStack, Text } from "@chakra-ui/react";
 import type {
   RpcAsset,
   TransactionStatus,
@@ -20,8 +20,8 @@ import { ExpiredIcon } from "./icons/ExpiredIcon";
 import { PendingIcon } from "./icons/PendingIcon";
 import { ReceivedIcon } from "./icons/ReceivedIcon";
 import { SentIcon } from "./icons/SentIcon";
-import { messages, CARET_WIDTH, useHeadingsText } from "./shared";
-import { CopyAddress } from "../CopyAddress/CopyAddress";
+import { CARET_WIDTH, messages, useHeadingsText } from "./shared";
+import { CopyToClipboard } from "../CopyToClipboard/CopyToClipboard";
 
 function getNoteStatusDisplay(
   type: TransactionType,
@@ -89,10 +89,10 @@ function NoteTo({
   }
 
   return (
-    <CopyAddress
+    <CopyToClipboard
       color={COLORS.BLACK}
       _dark={{ color: COLORS.WHITE }}
-      address={type === "send" ? to : from}
+      text={type === "send" ? to : from}
     />
   );
 }
@@ -139,7 +139,7 @@ export function NoteRow({
     from === to && type !== "miner",
     isBridge,
   );
-  const headings = useHeadingsText();
+  const headings = useHeadingsText(asTransaction);
 
   const cellContent = useMemo(() => {
     let key = 0;
@@ -151,7 +151,7 @@ export function NoteRow({
     );
     const symbol = CurrencyUtils.shortSymbol(assetId, asset);
 
-    return [
+    const row = [
       <HStack gap={4} key={key++}>
         {statusDisplay.icon}
         <Text as="span">{formatMessage(statusDisplay.message)}</Text>
@@ -173,6 +173,21 @@ export function NoteRow({
           : memo}
       </Text>,
     ];
+
+    if (asTransaction) {
+      row.push(
+        <Text as="span" key={key++}>
+          <CopyToClipboard
+            messageType="hashCopied"
+            color={COLORS.BLACK}
+            _dark={{ color: COLORS.WHITE }}
+            text={transactionHash}
+          />
+        </Text>,
+      );
+    }
+
+    return row;
   }, [
     asset,
     assetId,
@@ -186,6 +201,8 @@ export function NoteRow({
     to,
     type,
     value,
+    asTransaction,
+    transactionHash,
   ]);
 
   return (

--- a/renderer/components/NoteRow/shared.ts
+++ b/renderer/components/NoteRow/shared.ts
@@ -18,6 +18,9 @@ export const messages = defineMessages({
   memo: {
     defaultMessage: "Memo",
   },
+  transactionHash: {
+    defaultMessage: "Hash",
+  },
   sent: {
     defaultMessage: "Sent",
   },
@@ -49,13 +52,17 @@ export const messages = defineMessages({
   },
 });
 
-export function useHeadingsText() {
+export function useHeadingsText(asTransaction: boolean = false) {
   const { formatMessage } = useIntl();
-  return [
+  const headings = [
     formatMessage(messages.action),
     formatMessage(messages.amount),
     formatMessage(messages.fromTo),
     formatMessage(messages.date),
     formatMessage(messages.memo),
   ];
+  if (asTransaction) {
+    headings.push(formatMessage(messages.transactionHash));
+  }
+  return headings;
 }

--- a/renderer/components/TransactionInformation/TransactionInformation.tsx
+++ b/renderer/components/TransactionInformation/TransactionInformation.tsx
@@ -4,8 +4,8 @@ import {
   Grid,
   GridItem,
   Heading,
-  Text,
   HStack,
+  Text,
   VStack,
 } from "@chakra-ui/react";
 import { upperFirst } from "lodash-es";
@@ -24,7 +24,7 @@ import { ShadowCard } from "@/ui/ShadowCard/ShadowCard";
 import { formatDate } from "@/utils/formatDate";
 import { formatOre } from "@/utils/ironUtils";
 
-import { CopyAddress } from "../CopyAddress/CopyAddress";
+import { CopyToClipboard } from "../CopyToClipboard/CopyToClipboard";
 
 type Transaction = TRPCRouterOutputs["getTransaction"]["transaction"];
 
@@ -69,11 +69,12 @@ function TransactionHashBody({ transaction }: { transaction: Transaction }) {
 
   return (
     <VStack alignItems="flex-start">
-      <CopyAddress
+      <CopyToClipboard
         fontSize="md"
         color={COLORS.BLACK}
         _dark={{ color: COLORS.WHITE }}
-        address={transaction.hash}
+        text={transaction.hash}
+        messageType="hashCopied"
         parts={2}
       />
       {data && (

--- a/renderer/intl/locales/en-US.json
+++ b/renderer/intl/locales/en-US.json
@@ -165,6 +165,9 @@
   "9+Ddtu": {
     "message": "Next"
   },
+  "93oVTh": {
+    "message": "Copied to clipboard"
+  },
   "9DI6zl": {
     "message": "You can change the fee amount you'd like to pay. However, that will directly correlate with the speed with which your transaction is picked up by the blockchain."
   },
@@ -287,6 +290,9 @@
   },
   "IwW0RC": {
     "message": "If none of these steps help, please report the issue on <link>Discord</link>."
+  },
+  "Ix4/6C": {
+    "message": "Hash copied to clipboard"
   },
   "JJNc3c": {
     "message": "Previous"
@@ -489,6 +495,9 @@
   },
   "ThbkST": {
     "message": "Unable to load your transactions"
+  },
+  "TvwmZr": {
+    "message": "Hash"
   },
   "TzwzhT": {
     "message": "You can remove and reimport your accounts whenever you like, provided that you possess the account keys. It is highly recommended to maintain a backup of your account keys in a secure location."

--- a/renderer/pages/accounts/[account-name]/index.tsx
+++ b/renderer/pages/accounts/[account-name]/index.tsx
@@ -1,14 +1,14 @@
 import {
   Box,
-  Heading,
-  Tabs,
-  TabList,
-  Tab,
-  TabPanels,
-  TabPanel,
   HStack,
-  VStack,
+  Heading,
   Spinner,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  VStack,
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import { ReactNode, useMemo } from "react";
@@ -18,7 +18,7 @@ import { AccountAssets } from "@/components/AccountAssets/AccountAssets";
 import { AccountKeyExport } from "@/components/AccountKeyExport/AccountKeyExport";
 import { AccountMnemonicView } from "@/components/AccountMnemonicView/AccountMnenomicView";
 import { AccountSettings } from "@/components/AccountSettings/AccountSettings";
-import { CopyAddress } from "@/components/CopyAddress/CopyAddress";
+import { CopyToClipboard } from "@/components/CopyToClipboard/CopyToClipboard";
 import { LedgerChip } from "@/components/LedgerChip/LedgerChip";
 import { NotesList } from "@/components/NotesList/NotesList";
 import { ViewOnlyChip } from "@/components/ViewOnlyChip/ViewOnlyChip";
@@ -130,12 +130,12 @@ function AccountOverviewContent({ accountName }: { accountName: string }) {
             <Heading fontSize="28px">{accountData.name}</Heading>
             {headingChip}
           </HStack>
-          <CopyAddress
-            address={accountData.address}
+          <CopyToClipboard
+            text={accountData.address}
             truncate={false}
             transform="translateY(0.4em)"
           />
-        </VStack>
+        </VStack >
         <Tabs isLazy defaultIndex={initialTabIndex}>
           <TabList mb={8}>
             <Tab>{formatMessage(messages.accountOverview)}</Tab>
@@ -186,8 +186,8 @@ function AccountOverviewContent({ accountName }: { accountName: string }) {
             </TabPanel>
           </TabPanels>
         </Tabs>
-      </Box>
-    </MainLayout>
+      </Box >
+    </MainLayout >
   );
 }
 

--- a/renderer/pages/accounts/[account-name]/transaction/[transaction-hash].tsx
+++ b/renderer/pages/accounts/[account-name]/transaction/[transaction-hash].tsx
@@ -4,7 +4,7 @@ import { defineMessages, useIntl } from "react-intl";
 
 import { BridgeTransactionInformation } from "@/components/BridgeTransactionInformation/BridgeTransactionInformation";
 import { BridgeTransactionProgressIndicator } from "@/components/BridgeTransactionProgressIndicator/BridgeTransactionProgressIndicator";
-import { CopyAddress } from "@/components/CopyAddress/CopyAddress";
+import { CopyToClipboard } from "@/components/CopyToClipboard/CopyToClipboard";
 import { NotesList } from "@/components/NotesList/NotesList";
 import { TransactionInformation } from "@/components/TransactionInformation/TransactionInformation";
 import MainLayout from "@/layouts/MainLayout";
@@ -61,8 +61,8 @@ function SingleTransactionContent({
       >
         <HStack mb={8} gap={4}>
           <Heading>{accountName}</Heading>
-          <CopyAddress
-            address={accountData.address}
+          <CopyToClipboard
+            text={accountData.address}
             transform="translateY(0.4em)"
           />
         </HStack>
@@ -100,8 +100,8 @@ function SingleTransactionContent({
     >
       <HStack mb={8} gap={4}>
         <Heading>{accountName}</Heading>
-        <CopyAddress
-          address={accountData.address}
+        <CopyToClipboard
+          text={accountData.address}
           transform="translateY(0.4em)"
         />
       </HStack>

--- a/renderer/pages/address-book/[address]/index.tsx
+++ b/renderer/pages/address-book/[address]/index.tsx
@@ -1,22 +1,22 @@
 import {
   Box,
-  Heading,
-  Tabs,
-  TabList,
-  Tab,
-  TabPanels,
-  TabPanel,
-  HStack,
   Flex,
-  Text,
+  Heading,
+  HStack,
   Skeleton,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Text,
   VStack,
 } from "@chakra-ui/react";
 import Image from "next/image";
 import { useRouter } from "next/router";
 import { defineMessages, useIntl } from "react-intl";
 
-import { CopyAddress } from "@/components/CopyAddress/CopyAddress";
+import { CopyToClipboard } from "@/components/CopyToClipboard/CopyToClipboard";
 import { EditContactForm } from "@/components/EditContactForm/EditContactForm";
 import { FishIcon } from "@/components/FishIcon/FishIcon";
 import { NotesList } from "@/components/NotesList/NotesList";
@@ -92,7 +92,7 @@ function SingleContactContent({ address }: { address: string }) {
             {formatMessage(messages.send)}
           </PillButton>
         </HStack>
-        <CopyAddress address={contactData.address} truncate={false} />
+        <CopyToClipboard text={contactData.address} truncate={false} />
         <Tabs isLazy>
           <TabList mb={8}>
             <Tab>{formatMessage(messages.transactions)}</Tab>


### PR DESCRIPTION
Adds the hash of the transaction to the transactions list. 

Makes it easier to identify a specific transaction especially when a lot of them have similar total values

![image](https://github.com/iron-fish/ironfish-node-app/assets/13268167/6482a9db-b14b-41cd-a6b3-e10d33481f7a)
