### PR TITLE
Fix higher priority bug bash bugs

### DIFF
--- a/main/api/ledger/index.ts
+++ b/main/api/ledger/index.ts
@@ -1,4 +1,5 @@
 import { observable } from "@trpc/server/observable";
+import { z } from "zod";
 
 import { ledgerManager, ConnectionStatus } from "./utils/ledger";
 import { handleSendTransactionInput } from "../transactions/handleSendTransaction";
@@ -24,5 +25,17 @@ export const ledgerRouter = t.router({
     .input(handleSendTransactionInput)
     .mutation(async (opts) => {
       return ledgerManager.submitTransaction(opts.input);
+    }),
+  cancelSubmitLedgerTransaction: t.procedure.mutation(async () => {
+    return ledgerManager.cancelTransaction();
+  }),
+  markAccountAsLedger: t.procedure
+    .input(
+      z.object({
+        publicAddress: z.string(),
+      }),
+    )
+    .mutation((opts) => {
+      return ledgerManager.markAccountAsLedger(opts.input.publicAddress);
     }),
 });

--- a/renderer/components/ConnectLedgerModal/Steps/StepAddAccount.tsx
+++ b/renderer/components/ConnectLedgerModal/Steps/StepAddAccount.tsx
@@ -7,6 +7,7 @@ import {
   Heading,
   HStack,
   Text,
+  Tooltip,
 } from "@chakra-ui/react";
 import Image from "next/image";
 import { defineMessages, useIntl } from "react-intl";
@@ -24,6 +25,9 @@ const messages = defineMessages({
     defaultMessage:
       "One last step! Confirm the account you'd like to connect to the Node App.",
   },
+  alreadyImported: {
+    defaultMessage: "This Ledger account has already been imported",
+  },
 });
 
 type Props = {
@@ -31,6 +35,7 @@ type Props = {
   publicAddress: string;
   isConfirmed: boolean;
   onConfirmChange: (value: boolean) => void;
+  isImported: boolean;
 };
 
 export function StepAddAccount({
@@ -38,6 +43,7 @@ export function StepAddAccount({
   publicAddress,
   isConfirmed,
   onConfirmChange,
+  isImported,
 }: Props) {
   const { formatMessage } = useIntl();
 
@@ -49,7 +55,7 @@ export function StepAddAccount({
         fontSize="medium"
         color={COLORS.GRAY_MEDIUM}
         _dark={{
-          color: COLORS.DARK_MODE.GRAY_MEDIUM,
+          color: COLORS.DARK_MODE.GRAY_LIGHT,
         }}
       >
         {formatMessage(messages.description)}
@@ -61,10 +67,18 @@ export function StepAddAccount({
       >
         <HStack py={5} px={4} justifyContent="space-between">
           <Text fontSize="medium">{deviceName}</Text>
-          <Checkbox
-            isChecked={isConfirmed}
-            onChange={(e) => onConfirmChange(e.target.checked)}
-          />
+          <Tooltip
+            label={isImported ? formatMessage(messages.alreadyImported) : null}
+            placement="top"
+          >
+            <Box>
+              <Checkbox
+                isChecked={isConfirmed}
+                onChange={(e) => onConfirmChange(e.target.checked)}
+                disabled={isImported}
+              />
+            </Box>
+          </Tooltip>
         </HStack>
 
         <Box borderBottom="1px solid black" />
@@ -95,7 +109,7 @@ export function StepAddAccount({
                 wordBreak="break-all"
                 color={COLORS.GRAY_MEDIUM}
                 _dark={{
-                  color: COLORS.DARK_MODE.GRAY_MEDIUM,
+                  color: COLORS.DARK_MODE.GRAY_LIGHT,
                 }}
               >
                 {publicAddress}

--- a/renderer/components/ConnectLedgerModal/Steps/StepConnect.tsx
+++ b/renderer/components/ConnectLedgerModal/Steps/StepConnect.tsx
@@ -24,15 +24,6 @@ const messages = defineMessages({
   openApp: {
     defaultMessage: "Open the Iron Fish app",
   },
-  connectAccount: {
-    defaultMessage: "Connect account",
-  },
-  cancel: {
-    defaultMessage: "Cancel",
-  },
-  continue: {
-    defaultMessage: "Continue",
-  },
 });
 
 type Props = {

--- a/renderer/components/SendAssetsForm/ConfirmLedgerModal/ConfirmLedgerModal.tsx
+++ b/renderer/components/SendAssetsForm/ConfirmLedgerModal/ConfirmLedgerModal.tsx
@@ -83,6 +83,15 @@ export function ConfirmLedgerModal({
     },
   });
 
+  useEffect(() => {
+    if (
+      !["CONNECT_LEDGER", "ERROR"].includes(step) &&
+      (!isLedgerConnected || !isLedgerUnlocked || !isIronfishAppOpen)
+    ) {
+      setStep("CONNECT_LEDGER");
+    }
+  }, [step, isLedgerConnected, isLedgerUnlocked, isIronfishAppOpen]);
+
   const {
     mutate: submitTransaction,
     data: submittedTransactionData,
@@ -98,6 +107,9 @@ export function ConfirmLedgerModal({
     },
   });
 
+  const { mutate: cancelTransaction } =
+    trpcReact.cancelSubmitLedgerTransaction.useMutation();
+
   useEffect(() => {
     if (
       step === "CONFIRM_TRANSACTION" &&
@@ -108,9 +120,12 @@ export function ConfirmLedgerModal({
   }, [isLedgerConnected, isLedgerUnlocked, isIronfishAppOpen, step]);
 
   const handleClose = useCallback(() => {
+    if (step === "CONFIRM_TRANSACTION") {
+      cancelTransaction();
+    }
     reset();
     onCancel();
-  }, [onCancel, reset]);
+  }, [onCancel, reset, step, cancelTransaction]);
 
   return (
     <Modal isOpen={isOpen} onClose={handleClose}>

--- a/renderer/components/SendAssetsForm/SendAssetsForm.tsx
+++ b/renderer/components/SendAssetsForm/SendAssetsForm.tsx
@@ -193,8 +193,7 @@ export function SendAssetsFormContent({
           !errors.memo &&
           !errors.amount &&
           !errors.toAccount &&
-          !errors.assetId &&
-          !selectedAccount.isLedger,
+          !errors.assetId,
       },
     );
 
@@ -336,40 +335,38 @@ export function SendAssetsFormContent({
             )}
           />
 
-          {!selectedAccount.isLedger && (
-            <Select
-              {...register("fee")}
-              value={feeValue}
-              label={formatMessage(messages.feeLabel)}
-              options={[
-                {
-                  label:
-                    formatMessage(messages.slowFeeLabel) +
-                    (estimatedFeesData
-                      ? ` (${formatOre(estimatedFeesData.slow)} $IRON)`
-                      : ""),
-                  value: "slow",
-                },
-                {
-                  label:
-                    formatMessage(messages.averageFeeLabel) +
-                    (estimatedFeesData
-                      ? ` (${formatOre(estimatedFeesData.average)} $IRON)`
-                      : ""),
-                  value: "average",
-                },
-                {
-                  label:
-                    formatMessage(messages.fastFeeLabel) +
-                    (estimatedFeesData
-                      ? ` (${formatOre(estimatedFeesData.fast)} $IRON)`
-                      : ""),
-                  value: "fast",
-                },
-              ]}
-              error={errors.fee?.message}
-            />
-          )}
+          <Select
+            {...register("fee")}
+            value={feeValue}
+            label={formatMessage(messages.feeLabel)}
+            options={[
+              {
+                label:
+                  formatMessage(messages.slowFeeLabel) +
+                  (estimatedFeesData
+                    ? ` (${formatOre(estimatedFeesData.slow)} $IRON)`
+                    : ""),
+                value: "slow",
+              },
+              {
+                label:
+                  formatMessage(messages.averageFeeLabel) +
+                  (estimatedFeesData
+                    ? ` (${formatOre(estimatedFeesData.average)} $IRON)`
+                    : ""),
+                value: "average",
+              },
+              {
+                label:
+                  formatMessage(messages.fastFeeLabel) +
+                  (estimatedFeesData
+                    ? ` (${formatOre(estimatedFeesData.fast)} $IRON)`
+                    : ""),
+                value: "fast",
+              },
+            ]}
+            error={errors.fee?.message}
+          />
 
           <Controller
             name="memo"

--- a/renderer/intl/locales/en-US.json
+++ b/renderer/intl/locales/en-US.json
@@ -559,6 +559,9 @@
   "YFT4rG": {
     "message": "Keys"
   },
+  "Yeh8je": {
+    "message": "This Ledger account has already been imported"
+  },
   "Z7mY5w": {
     "message": "Confirm Transaction Details"
   },

--- a/renderer/ui/theme/styleConfigs/checkbox.ts
+++ b/renderer/ui/theme/styleConfigs/checkbox.ts
@@ -34,6 +34,11 @@ export const checkboxTheme = defineMultiStyleConfig({
           },
         },
 
+        _disabled: {
+          borderColor: COLORS.GRAY_MEDIUM,
+          bg: COLORS.GRAY_LIGHT,
+        },
+
         _dark: {
           borderColor: COLORS.WHITE,
           bg: COLORS.DARK_MODE.GRAY_MEDIUM,


### PR DESCRIPTION
- If a user has imported a view only account and it's not flagged as a Ledger in the Node App, the app will now allow the user to "import" that account but will just flag it as a Ledger account in the Ledger store
- If a user is in the "Confirm Transaction" step of the Ledger send flow, and they Cancel out of the modal, but they still approve the transaction from their Ledger device, that transaction will no longer be submitted to the network
- Adds back the network fee selector for Ledger accounts
- Minor UI feedback