### PR TITLE
Makes consistent spacing between accounts and search

### DIFF
--- a/renderer/components/UserAccountsList/UserAccountsList.tsx
+++ b/renderer/components/UserAccountsList/UserAccountsList.tsx
@@ -96,11 +96,11 @@ export function UserAccountsList() {
   const [sortOption, setSortOption] = useState<SortOption>(sortOptions[2]);
 
   return (
-    <VStack>
+    <VStack gap={4}>
       {nodeStatusData?.blockchain.synced === false ? (
         <ChainSyncingMessage mb={4} />
       ) : null}
-      <Grid w="100%" templateColumns="3fr 1fr" gap={4} mb={4}>
+      <Grid w="100%" templateColumns="3fr 1fr" gap={4}>
         <GridItem>
           <SearchInput onChange={(e) => setSearchInput(e.target.value)} />
         </GridItem>


### PR DESCRIPTION
https://linear.app/if-labs/issue/IFL-1932/accounts-general-spacing

Removes bottom margin on the search and bumps the gap value for the stack to 16px

<img width="682" alt="image" src="https://github.com/user-attachments/assets/456ba8da-67d9-48ad-bf31-aa44a7b919e4">
