### PR TITLE
Adds more spacing to address book columns

### DIFF
--- a/renderer/components/ContactRow/ContactRow.tsx
+++ b/renderer/components/ContactRow/ContactRow.tsx
@@ -29,8 +29,8 @@ export function ContactHeadings() {
   return (
     <Grid
       templateColumns={{
-        base: `1fr 3fr auto`,
-        md: `1fr 3fr auto 55px`,
+        base: `3fr 3fr 1fr`,
+        md: `3fr 3fr 1fr 55px`,
       }}
       opacity="0.8"
       mb={4}
@@ -38,7 +38,7 @@ export function ContactHeadings() {
       <GridItem pl={8}>
         <Text as="span">{formatMessage(messages.contact)}</Text>
       </GridItem>
-      <GridItem>
+      <GridItem pl={{ base: 0, lg: 8 }}>
         <Text as="span">{formatMessage(messages.address)}</Text>
       </GridItem>
     </Grid>
@@ -67,8 +67,8 @@ export function ContactRow({ name, address, order }: Props) {
       >
         <Grid
           templateColumns={{
-            base: `1fr 3fr auto`,
-            md: `1fr 3fr auto 55px`,
+            base: `3fr 3fr 1fr`,
+            md: `3fr 3fr 1fr 55px`,
           }}
           w="100%"
           gap={4}


### PR DESCRIPTION
https://linear.app/if-labs/issue/IFL-2089/address-book-columns-are-too-close-to-one-another

Adds more spacing between contact and address columns

<img width="914" alt="image" src="https://github.com/user-attachments/assets/5822c9cb-603d-4703-935f-2cc75f0d3b5e">

Fixes IFL-2089