### PR TITLE
Changes base grid to two columns

### DIFF
--- a/renderer/components/NodeOverview/NodeOverview.tsx
+++ b/renderer/components/NodeOverview/NodeOverview.tsx
@@ -117,8 +117,7 @@ export function NodeOverview() {
           <Grid
             position="relative"
             templateColumns={{
-              base: "repeat(1, 1fr)",
-              md: "repeat(2, 1fr)",
+              base: "repeat(2, 1fr)",
               lg: "repeat(3, min-content)",
             }}
             gap={8}


### PR DESCRIPTION
Fixes IFL-2083

Your node information will never become one column of information 

<img width="609" alt="image" src="https://github.com/user-attachments/assets/5933d0ab-44d7-4618-9806-acd0fe8215c3">
