### PR TITLE
Use Chainport fallback API temporarily

### DIFF
--- a/main/api/chainport/utils/getChainportEndpoints.ts
+++ b/main/api/chainport/utils/getChainportEndpoints.ts
@@ -16,7 +16,7 @@ export async function getChainportEndpoints() {
   }
 
   const baseUrl = `https://${prefix}api.chainport.io`;
-  const tokensEndpoint = `${baseUrl}/token/list?network_name=IRONFISH`;
+  const tokensEndpoint = `${baseUrl}/token_list?network_name=IRONFISH`;
   const metadataEndpoint = `${baseUrl}/meta`;
 
   return { baseUrl, tokensEndpoint, metadataEndpoint };


### PR DESCRIPTION
Use the chainport fallback token list API until the updates for the new API are ready.
