### PR TITLE
Adds info drawer that adjusts sidebar view based on screensize

### DIFF
--- a/renderer/intl/locales/en-US.json
+++ b/renderer/intl/locales/en-US.json
@@ -349,6 +349,9 @@
   "Ld49Lh": {
     "message": "What would you like to name this account? This name is only visible to you."
   },
+  "Lv0zJu": {
+    "message": "Details"
+  },
   "M+isB1": {
     "message": "Bridge Provider"
   },

--- a/renderer/layouts/WithExplanatorySidebar.tsx
+++ b/renderer/layouts/WithExplanatorySidebar.tsx
@@ -19,7 +19,7 @@ export function WithExplanatorySidebar({
   children,
 }: Props) {
   return (
-    <Flex gap={{ base: 8, lg: 16 }}>
+    <Flex gap={{ base: 4, lg: 16 }}>
       <Box
         maxW={{
           base: "100%",
@@ -27,7 +27,7 @@ export function WithExplanatorySidebar({
         }}
         w="100%"
       >
-        <>{children}</>
+        {children}
       </Box>
       <InfoDrawer>
         <Box>

--- a/renderer/layouts/WithExplanatorySidebar.tsx
+++ b/renderer/layouts/WithExplanatorySidebar.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { ReactNode } from "react";
 
 import { COLORS } from "@/ui/colors";
+import InfoDrawer from "@/ui/InfoDrawer/InfoDrawer";
 
 type Props = {
   heading: ReactNode;
@@ -18,7 +19,7 @@ export function WithExplanatorySidebar({
   children,
 }: Props) {
   return (
-    <Flex gap={16}>
+    <Flex gap={{ base: 8, lg: 16 }}>
       <Box
         maxW={{
           base: "100%",
@@ -26,22 +27,19 @@ export function WithExplanatorySidebar({
         }}
         w="100%"
       >
-        {children}
+        <>{children}</>
       </Box>
-      <Box
-        display={{
-          base: "none",
-          lg: "block",
-        }}
-      >
-        <Heading fontSize="2xl" mb={4}>
-          {heading}
-        </Heading>
-        <Description>{description}</Description>
-        <Box mt={8}>
-          <Image src={imgSrc} alt="" />
+      <InfoDrawer>
+        <Box>
+          <Heading fontSize="2xl" mb={4}>
+            {heading}
+          </Heading>
+          <Description>{description}</Description>
+          <Box mt={8}>
+            <Image src={imgSrc} alt="" />
+          </Box>
         </Box>
-      </Box>
+      </InfoDrawer>
     </Flex>
   );
 }

--- a/renderer/pages/send/index.tsx
+++ b/renderer/pages/send/index.tsx
@@ -1,13 +1,10 @@
-import { Heading, Text, Flex, Box } from "@chakra-ui/react";
-import Image from "next/image";
+import { Heading } from "@chakra-ui/react";
 import { defineMessages, useIntl } from "react-intl";
 
 import { SendAssetsForm } from "@/components/SendAssetsForm/SendAssetsForm";
 import treasureChest from "@/images/treasure-chest.svg";
 import MainLayout from "@/layouts/MainLayout";
-import { COLORS } from "@/ui/colors";
-import InfoDrawer from "@/ui/InfoDrawer/InfoDrawer";
-
+import { WithExplanatorySidebar } from "@/layouts/WithExplanatorySidebar";
 const messages = defineMessages({
   heading: {
     defaultMessage: "Send",
@@ -29,28 +26,13 @@ export default function Send() {
       <Heading fontSize={28} lineHeight="160%" mb={5}>
         {formatMessage(messages.heading)}
       </Heading>
-      <Flex gap={16}>
-        <Box maxW="592px" w="100%">
-          <SendAssetsForm />
-        </Box>
-        <Box>
-          <InfoDrawer>
-            <Heading fontSize="2xl" mb={4}>
-              {formatMessage(messages.aboutFees)}
-            </Heading>
-            <Text
-              fontSize="sm"
-              maxW="340px"
-              mb={8}
-              color={COLORS.GRAY_MEDIUM}
-              _dark={{ color: COLORS.DARK_MODE.GRAY_LIGHT }}
-            >
-              {formatMessage(messages.feeAmount)}
-            </Text>
-            <Image src={treasureChest} alt="" />
-          </InfoDrawer>
-        </Box>
-      </Flex>
+      <WithExplanatorySidebar
+        heading={formatMessage(messages.aboutFees)}
+        description={formatMessage(messages.feeAmount)}
+        imgSrc={treasureChest}
+      >
+        <SendAssetsForm />
+      </WithExplanatorySidebar>
     </MainLayout>
   );
 }

--- a/renderer/pages/send/index.tsx
+++ b/renderer/pages/send/index.tsx
@@ -6,6 +6,7 @@ import { SendAssetsForm } from "@/components/SendAssetsForm/SendAssetsForm";
 import treasureChest from "@/images/treasure-chest.svg";
 import MainLayout from "@/layouts/MainLayout";
 import { COLORS } from "@/ui/colors";
+import InfoDrawer from "@/ui/InfoDrawer/InfoDrawer";
 
 const messages = defineMessages({
   heading: {
@@ -33,19 +34,21 @@ export default function Send() {
           <SendAssetsForm />
         </Box>
         <Box>
-          <Heading fontSize="2xl" mb={4}>
-            {formatMessage(messages.aboutFees)}
-          </Heading>
-          <Text
-            fontSize="sm"
-            maxW="340px"
-            mb={8}
-            color={COLORS.GRAY_MEDIUM}
-            _dark={{ color: COLORS.DARK_MODE.GRAY_LIGHT }}
-          >
-            {formatMessage(messages.feeAmount)}
-          </Text>
-          <Image src={treasureChest} alt="" />
+          <InfoDrawer>
+            <Heading fontSize="2xl" mb={4}>
+              {formatMessage(messages.aboutFees)}
+            </Heading>
+            <Text
+              fontSize="sm"
+              maxW="340px"
+              mb={8}
+              color={COLORS.GRAY_MEDIUM}
+              _dark={{ color: COLORS.DARK_MODE.GRAY_LIGHT }}
+            >
+              {formatMessage(messages.feeAmount)}
+            </Text>
+            <Image src={treasureChest} alt="" />
+          </InfoDrawer>
         </Box>
       </Flex>
     </MainLayout>

--- a/renderer/ui/InfoDrawer/InfoDrawer.tsx
+++ b/renderer/ui/InfoDrawer/InfoDrawer.tsx
@@ -45,15 +45,18 @@ const InfoButton: React.FC<InfoButtonProps> = ({ children }) => {
           icon={<InfoOutlineIcon />}
           aria-label={formatMessage(messages.details)}
           onClick={onOpen}
+          rounded="full"
+          variant="outline"
+          _hover={{
+            bg: "rgba(0, 0, 0, 0.05)",
+          }}
           // position="fixed"
           // right={4}
-          rounded="full"
           // top={4}
-          variant="outline"
           // zIndex="overlay"
         />
       ) : (
-        <PillButton variant="inverted" gap={2} onClick={onOpen}>
+        <PillButton variant="inverted" borderWidth={1} gap={2} onClick={onOpen}>
           <InfoOutlineIcon />
           {formatMessage(messages.details)}
         </PillButton>

--- a/renderer/ui/InfoDrawer/InfoDrawer.tsx
+++ b/renderer/ui/InfoDrawer/InfoDrawer.tsx
@@ -29,18 +29,19 @@ const InfoButton: React.FC<InfoButtonProps> = ({ children }) => {
   const { formatMessage } = useIntl();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const displayMode = useBreakpointValue({
-    base: "mobile",
-    md: "tablet",
-    lg: "desktop",
+    base: "sm",
+    md: "md",
+    lg: "lg",
   });
 
-  if (displayMode === "desktop") {
+  // Large display mode shows no drawer
+  if (displayMode === "lg") {
     return <Box>{children}</Box>;
   }
 
   return (
     <>
-      {displayMode === "mobile" ? (
+      {displayMode === "sm" ? (
         <IconButton
           icon={<MdInfo />}
           aria-label={formatMessage(messages.details)}

--- a/renderer/ui/InfoDrawer/InfoDrawer.tsx
+++ b/renderer/ui/InfoDrawer/InfoDrawer.tsx
@@ -1,4 +1,3 @@
-import { InfoOutlineIcon } from "@chakra-ui/icons";
 import {
   Drawer,
   DrawerBody,
@@ -11,6 +10,7 @@ import {
   IconButton,
 } from "@chakra-ui/react";
 import React from "react";
+import { MdInfo } from "react-icons/md";
 import { defineMessages, useIntl } from "react-intl";
 
 import { PillButton } from "@/ui/PillButton/PillButton";
@@ -42,29 +42,38 @@ const InfoButton: React.FC<InfoButtonProps> = ({ children }) => {
     <>
       {displayMode === "mobile" ? (
         <IconButton
-          icon={<InfoOutlineIcon />}
+          icon={<MdInfo />}
           aria-label={formatMessage(messages.details)}
           onClick={onOpen}
           rounded="full"
           variant="outline"
+          borderColor="black"
           _hover={{
             bg: "rgba(0, 0, 0, 0.05)",
           }}
-          // position="fixed"
-          // right={4}
-          // top={4}
-          // zIndex="overlay"
         />
       ) : (
-        <PillButton variant="inverted" borderWidth={1} gap={2} onClick={onOpen}>
-          <InfoOutlineIcon />
+        <PillButton
+          size="sm"
+          height="fit-content"
+          variant="inverted"
+          borderWidth={1}
+          gap={2}
+          onClick={onOpen}
+        >
+          <MdInfo />
           {formatMessage(messages.details)}
         </PillButton>
       )}
       <Drawer isOpen={isOpen} placement="right" onClose={onClose}>
         <DrawerOverlay />
         <DrawerContent px={4} pt={16}>
-          <DrawerCloseButton />
+          <DrawerCloseButton
+            mt={1}
+            borderRadius="full"
+            borderWidth={1}
+            borderColor="black"
+          />
           <DrawerBody>{children}</DrawerBody>
         </DrawerContent>
       </Drawer>

--- a/renderer/ui/InfoDrawer/InfoDrawer.tsx
+++ b/renderer/ui/InfoDrawer/InfoDrawer.tsx
@@ -1,0 +1,72 @@
+import { InfoOutlineIcon } from "@chakra-ui/icons";
+import {
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerOverlay,
+  useDisclosure,
+  Box,
+  useBreakpointValue,
+  IconButton,
+} from "@chakra-ui/react";
+import React from "react";
+import { defineMessages, useIntl } from "react-intl";
+
+import { PillButton } from "@/ui/PillButton/PillButton";
+
+const messages = defineMessages({
+  details: {
+    defaultMessage: "Details",
+  },
+});
+
+interface InfoButtonProps {
+  children: React.ReactNode;
+}
+
+const InfoButton: React.FC<InfoButtonProps> = ({ children }) => {
+  const { formatMessage } = useIntl();
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const displayMode = useBreakpointValue({
+    base: "mobile",
+    md: "tablet",
+    lg: "desktop",
+  });
+
+  if (displayMode === "desktop") {
+    return <Box>{children}</Box>;
+  }
+
+  return (
+    <>
+      {displayMode === "mobile" ? (
+        <IconButton
+          icon={<InfoOutlineIcon />}
+          aria-label={formatMessage(messages.details)}
+          onClick={onOpen}
+          // position="fixed"
+          // right={4}
+          rounded="full"
+          // top={4}
+          variant="outline"
+          // zIndex="overlay"
+        />
+      ) : (
+        <PillButton variant="inverted" gap={2} onClick={onOpen}>
+          <InfoOutlineIcon />
+          {formatMessage(messages.details)}
+        </PillButton>
+      )}
+      <Drawer isOpen={isOpen} placement="right" onClose={onClose}>
+        <DrawerOverlay />
+        <DrawerContent px={4} pt={16}>
+          <DrawerCloseButton />
+          <DrawerBody>{children}</DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    </>
+  );
+};
+
+export default InfoButton;


### PR DESCRIPTION
Fixes IFL-1972

Adds an `InfoDrawer` UI component that displays content on large screen sizes and minimizes it to details buttons that toggle a drawer to slide out from the right side of the screen. This PR should update all views that have a right sided info section to have this functionality

<img width="1236" alt="image" src="https://github.com/user-attachments/assets/6f46fb1b-0de0-44ce-96f8-998cd89b8990">

<img width="1092" alt="image" src="https://github.com/user-attachments/assets/c0b7aced-94e1-4999-a326-b493115d4162">

<img width="828" alt="image" src="https://github.com/user-attachments/assets/c2770ab3-4f2e-4160-aa58-50e49c0ebedc">

<img width="827" alt="image" src="https://github.com/user-attachments/assets/3f473669-38f0-4277-aa37-e386bb60cb37">
