### PR TITLE
Account custom assets chip

### DIFF
--- a/renderer/components/AccountRow/AccountRow.tsx
+++ b/renderer/components/AccountRow/AccountRow.tsx
@@ -8,7 +8,6 @@ import {
   Tooltip,
   VStack,
 } from "@chakra-ui/react";
-import type { RpcAsset } from "@ironfish/sdk";
 import { useRouter } from "next/router";
 import { defineMessages, useIntl } from "react-intl";
 
@@ -42,6 +41,9 @@ const messages = defineMessages({
   receiveButton: {
     defaultMessage: "Receive",
   },
+  customAssets: {
+    defaultMessage: "{count, plural, =1 {asset} other {assets}}",
+  },
 });
 
 type AccountRowProps = {
@@ -51,7 +53,7 @@ type AccountRowProps = {
   address: string;
   viewOnly: boolean;
   isLedger: boolean;
-  otherAssets: RpcAsset[];
+  numOfCustomAssets: number;
 };
 
 export function AccountRow({
@@ -61,7 +63,7 @@ export function AccountRow({
   address,
   viewOnly,
   isLedger,
-  otherAssets,
+  numOfCustomAssets,
 }: AccountRowProps) {
   const router = useRouter();
   const { formatMessage } = useIntl();
@@ -117,11 +119,13 @@ export function AccountRow({
                 {formatOre(balance)} $IRON
               </Heading>
               <HStack>
-                {otherAssets.length > 0 && (
+                {numOfCustomAssets > 0 && (
                   <InfoChip
-                    label={`+${otherAssets.length} ${
-                      otherAssets.length === 1 ? "asset" : "assets"
-                    }`}
+                    textProps={{ color: "muted" }}
+                    label={`+${numOfCustomAssets} ${formatMessage(
+                      messages.customAssets,
+                      { count: numOfCustomAssets },
+                    )}`}
                   />
                 )}
                 <CopyAddress address={address} />

--- a/renderer/components/AccountRow/AccountRow.tsx
+++ b/renderer/components/AccountRow/AccountRow.tsx
@@ -8,12 +8,14 @@ import {
   Tooltip,
   VStack,
 } from "@chakra-ui/react";
+import type { RpcAsset } from "@ironfish/sdk";
 import { useRouter } from "next/router";
 import { defineMessages, useIntl } from "react-intl";
 
 import { trpcReact } from "@/providers/TRPCProvider";
 import { ChakraLink } from "@/ui/ChakraLink/ChakraLink";
 import { COLORS } from "@/ui/colors";
+import { InfoChip } from "@/ui/InfoChip/InfoChip";
 import { PillButton } from "@/ui/PillButton/PillButton";
 import { ShadowCard, type GradientOptions } from "@/ui/ShadowCard/ShadowCard";
 import { ArrowReceive } from "@/ui/SVGs/ArrowReceive";
@@ -49,6 +51,7 @@ type AccountRowProps = {
   address: string;
   viewOnly: boolean;
   isLedger: boolean;
+  otherAssets: RpcAsset[];
 };
 
 export function AccountRow({
@@ -58,6 +61,7 @@ export function AccountRow({
   address,
   viewOnly,
   isLedger,
+  otherAssets,
 }: AccountRowProps) {
   const router = useRouter();
   const { formatMessage } = useIntl();
@@ -112,7 +116,16 @@ export function AccountRow({
               <Heading as="span" fontWeight="regular" fontSize="2xl">
                 {formatOre(balance)} $IRON
               </Heading>
-              <CopyAddress address={address} />
+              <HStack>
+                {otherAssets.length > 0 && (
+                  <InfoChip
+                    label={`+${otherAssets.length} ${
+                      otherAssets.length === 1 ? "asset" : "assets"
+                    }`}
+                  />
+                )}
+                <CopyAddress address={address} />
+              </HStack>
             </VStack>
 
             <VStack

--- a/renderer/components/AccountRow/AccountRow.tsx
+++ b/renderer/components/AccountRow/AccountRow.tsx
@@ -122,7 +122,7 @@ export function AccountRow({
                 {numOfCustomAssets > 0 && (
                   <InfoChip
                     textProps={{ color: "muted" }}
-                    label={`+${numOfCustomAssets} ${formatMessage(
+                    label={`${numOfCustomAssets} ${formatMessage(
                       messages.customAssets,
                       { count: numOfCustomAssets },
                     )}`}

--- a/renderer/components/UserAccountsList/UserAccountsList.tsx
+++ b/renderer/components/UserAccountsList/UserAccountsList.tsx
@@ -144,7 +144,7 @@ export function UserAccountsList() {
               address={account.address}
               viewOnly={account.status.viewOnly}
               isLedger={account.isLedger}
-              otherAssets={account.balances.custom.map((asset) => asset.asset)}
+              numOfCustomAssets={account.balances.custom.length}
             />
           );
         })}

--- a/renderer/components/UserAccountsList/UserAccountsList.tsx
+++ b/renderer/components/UserAccountsList/UserAccountsList.tsx
@@ -144,6 +144,7 @@ export function UserAccountsList() {
               address={account.address}
               viewOnly={account.status.viewOnly}
               isLedger={account.isLedger}
+              otherAssets={account.balances.custom.map((asset) => asset.asset)}
             />
           );
         })}

--- a/renderer/intl/locales/en-US.json
+++ b/renderer/intl/locales/en-US.json
@@ -162,6 +162,9 @@
   "8WtyrD": {
     "message": "Spanish"
   },
+  "8ZKRcK": {
+    "message": "{count, plural, =1 {asset} other {assets}}"
+  },
   "9+Ddtu": {
     "message": "Next"
   },

--- a/renderer/ui/InfoChip/InfoChip.tsx
+++ b/renderer/ui/InfoChip/InfoChip.tsx
@@ -1,4 +1,4 @@
-import { Tooltip, Text, HStack } from "@chakra-ui/react";
+import { Tooltip, Text, type TextProps, HStack } from "@chakra-ui/react";
 import { ReactNode } from "react";
 
 import { COLORS } from "@/ui/colors";
@@ -32,9 +32,11 @@ function MaybeTooltip({
 
 export function InfoChip({
   label,
+  textProps,
   tooltipMessage,
 }: {
   label: string;
+  textProps?: TextProps;
   tooltipMessage?: string;
 }) {
   return (
@@ -62,7 +64,9 @@ export function InfoChip({
         }}
       >
         {tooltipMessage && <Icon />}
-        <Text fontSize="12px">{label}</Text>
+        <Text fontSize="12px" {...textProps}>
+          {label}
+        </Text>
       </HStack>
     </MaybeTooltip>
   );


### PR DESCRIPTION
Fixes IFL-2069

Adds a chip to the account row item showing the number of custom assets in an account

<img width="1101" alt="image" src="https://github.com/user-attachments/assets/a58ae853-acfe-47cb-bf3a-ffde17e24e64">
