### PR TITLE
Filter out fee_payment row in Account Overview

### DIFF
--- a/main/api/transactions/handleGetTransactions.ts
+++ b/main/api/transactions/handleGetTransactions.ts
@@ -27,10 +27,13 @@ export async function handleGetTransactions({
     transactionsStream.contentStream(),
   );
 
+  const networkId = (await rpcClient.chain.getNetworkInfo()).content.networkId;
+
   const notes = await formatTransactionsToNotes(
     rpcClient,
     transactions,
     accountName,
+    networkId,
   );
 
   return {

--- a/main/api/transactions/handleGetTransactionsForContact.ts
+++ b/main/api/transactions/handleGetTransactionsForContact.ts
@@ -37,10 +37,14 @@ export async function handleGetTransactionsForContact({
       }
     }
 
+    const networkId = (await rpcClient.chain.getNetworkInfo()).content
+      .networkId;
+
     const notes = await formatTransactionsToNotes(
       rpcClient,
       transactions,
       accountName,
+      networkId,
     );
 
     result.push(...notes);

--- a/renderer/components/NotesList/NotesList.tsx
+++ b/renderer/components/NotesList/NotesList.tsx
@@ -5,7 +5,7 @@ import { Virtuoso } from "react-virtuoso";
 import { NoteHeadings } from "@/components/NoteRow/NoteHeadings";
 import { NoteRow } from "@/components/NoteRow/NoteRow";
 import { useScrollElementContext } from "@/layouts/MainLayout";
-import { isChainportNote } from "@/utils/chainport/isChainportTx";
+import { isChainportNote } from "@shared/isChainportTx";
 
 import { TransactionNote } from "../../../shared/types";
 import { EmptyStateMessage } from "../EmptyStateMessage/EmptyStateMessage";

--- a/renderer/next.config.js
+++ b/renderer/next.config.js
@@ -1,10 +1,13 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const path = require("path");
+
 /** @type {import('next').NextConfig} */
 module.exports = {
   trailingSlash: true,
   images: {
     unoptimized: true,
   },
-  webpack: (config, { isServer }) => {
+  webpack: (config, { isServer, defaultLoaders }) => {
     if (!isServer) {
       config.target = "web";
       config.node = {
@@ -12,6 +15,15 @@ module.exports = {
       };
     }
     config.output.globalObject = "this";
+
+    // Make the shared folder available to the renderer
+    config.resolve.modules.push(path.resolve(__dirname, "../"));
+    config.module.rules.push({
+      test: /\.ts$/,
+      include: path.resolve(__dirname, "../shared"),
+      use: [defaultLoaders.babel],
+    });
+
     return config;
   },
 };

--- a/renderer/pages/accounts/[account-name]/transaction/[transaction-hash].tsx
+++ b/renderer/pages/accounts/[account-name]/transaction/[transaction-hash].tsx
@@ -9,8 +9,8 @@ import { NotesList } from "@/components/NotesList/NotesList";
 import { TransactionInformation } from "@/components/TransactionInformation/TransactionInformation";
 import MainLayout from "@/layouts/MainLayout";
 import { trpcReact } from "@/providers/TRPCProvider";
-import { isChainportTx } from "@/utils/chainport/isChainportTx";
 import { asQueryString } from "@/utils/parseRouteQuery";
+import { isChainportTx } from "@shared/isChainportTx";
 
 const messages = defineMessages({
   backToAccountOverview: {

--- a/renderer/tsconfig.json
+++ b/renderer/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "../shared/**/*.ts"],
   "exclude": ["node_modules"],
   "compilerOptions": {
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@shared/*": ["../shared/*"]
     }
   }
 }

--- a/shared/isChainportTx.ts
+++ b/shared/isChainportTx.ts
@@ -1,4 +1,4 @@
-import { TRPCRouterOutputs } from "@/providers/TRPCProvider";
+import { TransactionType } from "@ironfish/sdk";
 
 const chainportConfig = {
   0: {
@@ -30,10 +30,17 @@ const chainportConfig = {
   },
 };
 
-type TransactionData = TRPCRouterOutputs["getTransaction"];
-type TransactionNote = TransactionData["notes"][number];
+type PartialTransactionWithNotes = {
+  notes: Array<PartialNote>;
+};
 
-export function isChainportNote(networkId: number, note: TransactionNote) {
+type PartialNote = {
+  type: TransactionType;
+  to: string | string[];
+  from: string;
+};
+
+export function isChainportNote(networkId: number, note: PartialNote) {
   if (networkId !== 1 && networkId !== 0) {
     throw new Error(`Unknown network id: ${networkId}`);
   }
@@ -53,11 +60,23 @@ export function isChainportNote(networkId: number, note: TransactionNote) {
 
 export function isChainportTx(
   networkId: number,
-  transactionData: TransactionData,
+  transactionData: PartialTransactionWithNotes,
 ) {
   return transactionData.notes.some((note) => {
     return isChainportNote(networkId, note);
   });
+}
+
+export function hasChainportOutgoingAddress(
+  networkId: number,
+  address: string,
+) {
+  if (networkId !== 1 && networkId !== 0) {
+    throw new Error(`Unknown network id: ${networkId}`);
+  }
+
+  const config = chainportConfig[networkId];
+  return hasAddress(config.outgoingAddresses, toLower(address));
 }
 
 function toLower(content: string | string[]) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,10 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "paths": {
+      "@shared/*": ["./shared/*"]
+    }
   },
-  "exclude": ["node_modules", "renderer/next.config.js", "app", "dist"]
+  "exclude": ["node_modules", "renderer/next.config.js", "app", "dist"],
 }


### PR DESCRIPTION
In order to make sure that we only show one row for Chainport bridge transactions, we have to massage the data for bridge transactions that bridge out a custom asset. That is because the Chainport fee_payment is paid in $IRON, so the transaction will have two asset balance deltas (one for the custom asset being sent, and one for the $IRON fee payment).

This PR adds a check in the transaction to note formatter to identify Chainport transactions with > 1 deltas, and skips the IRON asset balance delta if a custom asset is being bridged.

Fixes IFL-2991