### PR TITLE
Fix bridge confirmation modal refreshing periodically

### DIFF
--- a/renderer/components/BridgeAssetsForm/BridgeConfirmationModal/BridgeConfirmationModal.tsx
+++ b/renderer/components/BridgeAssetsForm/BridgeConfirmationModal/BridgeConfirmationModal.tsx
@@ -104,9 +104,9 @@ export function BridgeConfirmationModal({
 
   const {
     data: txDetails,
-    isLoading: isTransactionDetailsLoading,
     isError: isTransactionDetailError,
     error: transactionDetailError,
+    isFetching: isTransactionDetailsLoading,
   } = trpcReact.getChainportBridgeTransactionDetails.useQuery(
     {
       amount: convertedAmount.toString(),
@@ -116,6 +116,7 @@ export function BridgeConfirmationModal({
     },
     {
       retry: false,
+      refetchInterval: false,
       refetchOnWindowFocus: false,
       cacheTime: 0,
     },


### PR DESCRIPTION
Disable the refetch on the bridge confirmation modal and also show the loading screen on all subsequent fetches (there shouldn't be any though)

Fixes IFL-3026
