### PR TITLE
Appends accounts to the To address drop down

### DIFF
--- a/renderer/components/SendAssetsForm/SendAssetsForm.tsx
+++ b/renderer/components/SendAssetsForm/SendAssetsForm.tsx
@@ -236,15 +236,27 @@ export function SendAssetsFormContent({
   }, [assetIdValue, resetField, selectedAccount, accountBalances]);
 
   const { data: contactsData } = trpcReact.getContacts.useQuery();
+  const { data: allAccountsData } = trpcReact.getAccounts.useQuery();
+
   const formattedContacts = useMemo(() => {
-    return contactsData?.map((contact) => ({
+    const contacts = contactsData?.map((contact) => ({
       value: contact.address,
       label: {
         main: contact.name,
         sub: truncateString(contact.address, 2),
       },
     }));
-  }, [contactsData]);
+
+    const accounts = allAccountsData?.map((account) => ({
+      value: account.address,
+      label: {
+        main: account.name,
+        sub: truncateString(account.address, 2),
+      },
+    }));
+
+    return [...(contacts ?? []), ...(accounts ?? [])];
+  }, [contactsData, allAccountsData]);
 
   return (
     <>


### PR DESCRIPTION
This is a quality of life improvement. When I send an asset, I usually send it to another one of my accounts. I have been manually adding those accounts to the address book. This change will automatically show those accounts in the dropdown for the To field.

Only top three in my contacts: 

![image](https://github.com/user-attachments/assets/bd8b8e66-cc26-48d8-aee4-15ada39f95a4)