### PR TITLE
Various bridge page improvements

### DIFF
--- a/renderer/components/BridgeAssetsForm/BridgeConfirmationModal/StepIdle.tsx
+++ b/renderer/components/BridgeAssetsForm/BridgeConfirmationModal/StepIdle.tsx
@@ -6,6 +6,7 @@ import {
   Flex,
   Code,
   Text,
+  Box,
 } from "@chakra-ui/react";
 import { UseTRPCQueryResult } from "@trpc/react-query/dist/shared";
 import { ReactNode } from "react";
@@ -29,6 +30,10 @@ const messages = defineMessages({
   },
   bridgeProviderLabel: {
     defaultMessage: "Bridge Provider",
+  },
+  bridgeProviderTerms: {
+    defaultMessage:
+      "By bridging your assets, you agree to Chainport's <link>terms of service</link>.",
   },
   sourceNetworkLabel: {
     defaultMessage: "Source Network",
@@ -124,6 +129,27 @@ export function StepIdle({
           icon={chainportIcon}
           href="https://www.chainport.io/"
         />
+
+        <Text
+          color={COLORS.GRAY_MEDIUM}
+          _dark={{
+            color: COLORS.DARK_MODE.GRAY_LIGHT,
+          }}
+        >
+          {formatMessage(messages.bridgeProviderTerms, {
+            link: (msg: ReactNode) => (
+              <Box
+                as="a"
+                rel="noreferrer"
+                target="_blank"
+                textDecoration="underline"
+                href="https://www.chainport.io/terms-of-services"
+              >
+                {msg}
+              </Box>
+            ),
+          })}
+        </Text>
 
         <Divider />
 

--- a/renderer/components/BridgeAssetsForm/BridgeConfirmationModal/StepIdle.tsx
+++ b/renderer/components/BridgeAssetsForm/BridgeConfirmationModal/StepIdle.tsx
@@ -45,7 +45,11 @@ const messages = defineMessages({
     defaultMessage: "Sending",
   },
   receivingLabel: {
-    defaultMessage: "Receiving",
+    defaultMessage: "Receiving (Estimated)",
+  },
+  receivingTooltip: {
+    defaultMessage:
+      "Sending amount minus the bridge fee. This is an estimate, and you may receive a slightly different amount.",
   },
   targetAddressLabel: {
     defaultMessage: "Target Address",
@@ -203,6 +207,7 @@ export function StepIdle({
             <LineItem
               label={formatMessage(messages.receivingLabel)}
               content={amountReceiving}
+              tooltip={formatMessage(messages.receivingTooltip)}
               icon={chainportIcon}
             />
           </GridItem>

--- a/renderer/components/BridgeAssetsForm/BridgeConfirmationModal/StepIdle.tsx
+++ b/renderer/components/BridgeAssetsForm/BridgeConfirmationModal/StepIdle.tsx
@@ -58,7 +58,7 @@ const messages = defineMessages({
     defaultMessage: "Gas fee",
   },
   gasFeeTooltip: {
-    defaultMessage: "The fee for transacting on the destination chain",
+    defaultMessage: "The fee for transacting on the target network",
   },
   bridgeFeeLabel: {
     defaultMessage: "Bridge fee",

--- a/renderer/components/BridgeAssetsForm/BridgeConfirmationModal/StepIdle.tsx
+++ b/renderer/components/BridgeAssetsForm/BridgeConfirmationModal/StepIdle.tsx
@@ -152,9 +152,11 @@ export function StepIdle({
             mx={8}
           >
             <Flex
+              _dark={{
+                bg: "#431848",
+              }}
               bg="#F3DEF5"
               color={COLORS.ORCHID}
-              border="3px solid white"
               borderRadius={4}
               alignItems="center"
               justifyContent="center"

--- a/renderer/intl/locales/en-US.json
+++ b/renderer/intl/locales/en-US.json
@@ -93,6 +93,9 @@
   "3euoRJ": {
     "message": "Recovery Phrase"
   },
+  "3v74IM": {
+    "message": "By bridging your assets, you agree to Chainport's <link>terms of service</link>."
+  },
   "47FYwb": {
     "message": "Cancel"
   },

--- a/renderer/intl/locales/en-US.json
+++ b/renderer/intl/locales/en-US.json
@@ -661,9 +661,6 @@
   "c/KktL": {
     "message": "Resources"
   },
-  "cwqQqt": {
-    "message": "The fee for transacting on the destination chain"
-  },
   "dJMieh": {
     "message": "Connect account"
   },
@@ -873,6 +870,9 @@
   },
   "rqrhXg": {
     "message": "Confirm Your Recovery Phrase"
+  },
+  "ru6717": {
+    "message": "The fee for transacting on the target network"
   },
   "sXlL42": {
     "message": "Encrypted Wallets Unsupported"

--- a/renderer/intl/locales/en-US.json
+++ b/renderer/intl/locales/en-US.json
@@ -153,6 +153,9 @@
   "6q3tCn": {
     "message": "Connecting"
   },
+  "6ugwQB": {
+    "message": "Receiving (Estimated)"
+  },
   "7/GPHF": {
     "message": "Iron Fish transaction fee"
   },
@@ -343,6 +346,9 @@
     "description": "Change as in the money that is returned to the sender after a transaction",
     "message": "Change"
   },
+  "KIbwgQ": {
+    "message": "Sending amount minus the bridge fee. This is an estimate, and you may receive a slightly different amount."
+  },
   "KJMlfb": {
     "message": "Destination network"
   },
@@ -435,9 +441,6 @@
   },
   "OC6jXV": {
     "message": "Transaction Expiration Delta"
-  },
-  "OEEl0G": {
-    "message": "Receiving"
   },
   "OfA95/": {
     "message": "Selected file: {fileName}"


### PR DESCRIPTION
Added a link to the chainport TOS and changed "receiving" to an estimate. Also fixed the bridge confirmation modal icon in dark mode and changed the text "destination chain" to "target network" since we use that phrase everywhere else.

<img width="645" alt="image" src="https://github.com/user-attachments/assets/831a288b-3e3f-4c26-8bcf-7f19d620b300">


