### PR TITLE
Add token and network icons and use token name

### DIFF
--- a/main/api/chainport/index.ts
+++ b/main/api/chainport/index.ts
@@ -11,7 +11,7 @@ import {
   fetchChainportTokens,
   fetchChainportTransactionStatus,
 } from "./vendor/requests";
-import { ChainportNetwork } from "./vendor/types";
+import { ChainportTokenWithNetwork } from "./vendor/types";
 import {
   assertTokenPathsApiResponse,
   assertTokensApiResponse,
@@ -52,7 +52,9 @@ ${err}
       }),
     )
     .query(
-      async (opts): Promise<{ chainportTokenPaths: ChainportNetwork[] }> => {
+      async (
+        opts,
+      ): Promise<{ chainportTokenPaths: ChainportTokenWithNetwork[] }> => {
         const ironfish = await manager.getIronfish();
         const rpcClient = await ironfish.rpcClient();
         const network = await rpcClient.chain.getNetworkInfo();

--- a/main/api/chainport/vendor/requests.ts
+++ b/main/api/chainport/vendor/requests.ts
@@ -8,6 +8,7 @@ import {
   ChainportBridgeTransaction,
   ChainportNetwork,
   ChainportToken,
+  ChainportTokenWithNetwork,
   ChainportTransactionStatus,
 } from "./types";
 
@@ -45,13 +46,16 @@ export const fetchChainportTokens = async (
 export const fetchChainportTokenPaths = async (
   networkId: number,
   tokenId: number,
-): Promise<ChainportNetwork[]> => {
+): Promise<ChainportTokenWithNetwork[]> => {
   const config = getConfig(networkId);
-  const url = new URL(
-    `/bridges/tokens/${tokenId}/networks`,
-    config.endpoint,
-  ).toString();
-  return (await makeChainportRequest<{ data: ChainportNetwork[] }>(url)).data;
+  const url = new URL(`/bridges/tokens/${tokenId}/networks`, config.endpoint);
+  url.searchParams.append("with_tokens", true.toString());
+
+  return (
+    await makeChainportRequest<{ data: ChainportTokenWithNetwork[] }>(
+      url.toString(),
+    )
+  ).data;
 };
 
 export const fetchChainportBridgeTransaction = async (

--- a/main/api/chainport/vendor/types.ts
+++ b/main/api/chainport/vendor/types.ts
@@ -46,6 +46,11 @@ export type ChainportToken = {
   is_lifi: boolean;
 };
 
+export type ChainportTokenWithNetwork = {
+  network: ChainportNetwork;
+  token: ChainportToken;
+};
+
 export type ChainportTransactionStatus =
   | Record<string, never> // empty object
   | {

--- a/renderer/components/AssetAmountInput/AssetAmountInput.tsx
+++ b/renderer/components/AssetAmountInput/AssetAmountInput.tsx
@@ -52,6 +52,12 @@ export function AssetAmountInput({
           }}
           renderChildren={(children) => (
             <HStack minWidth="100px">
+              <Image
+                src={selectedAsset?.asset.verification.logoURI ?? ""}
+                alt=""
+                height="24"
+                width="24"
+              />
               {children}
               {selectedAsset?.asset.verification.status === "verified" && (
                 <Image src={verifiedIcon} alt="" />

--- a/renderer/components/BridgeAssetsForm/BridgeAssetsForm.tsx
+++ b/renderer/components/BridgeAssetsForm/BridgeAssetsForm.tsx
@@ -138,6 +138,12 @@ function BridgeAssetsFormContent({
           ...item,
           label: (
             <HStack>
+              <Image
+                src={item.asset.verification.logoURI ?? ""}
+                alt=""
+                width="24"
+                height="24"
+              />
               <ItemText>{item.label}</ItemText>
               {item.asset.verification.status === "verified" && (
                 <Image src={verifiedIcon} alt="" />
@@ -158,7 +164,7 @@ function BridgeAssetsFormContent({
 
   const selectedAsset = assetOptionsMap.get(assetIdValue);
   const selectedNetwork = availableNetworks?.find(
-    (n) => destinationNetworkId === n.chainport_network_id.toString(),
+    (n) => destinationNetworkId === n.network.chainport_network_id.toString(),
   );
 
   const handleIfAmountExceedsBalance = useCallback(
@@ -229,7 +235,7 @@ function BridgeAssetsFormContent({
     ) {
       setValue(
         "destinationNetworkId",
-        availableNetworks[0].chainport_network_id.toString(),
+        availableNetworks[0].network.chainport_network_id.toString(),
       );
     }
   }, [availableNetworks, destinationNetworkId, setValue]);
@@ -242,7 +248,8 @@ function BridgeAssetsFormContent({
 
           const destinationNetwork = availableNetworks?.find(
             (n) =>
-              data.destinationNetworkId === n.chainport_network_id.toString(),
+              data.destinationNetworkId ===
+              n.network.chainport_network_id.toString(),
           );
           if (!destinationNetwork) {
             return;
@@ -372,14 +379,24 @@ function BridgeAssetsFormContent({
                 value={destinationNetworkId ?? undefined}
                 label={formatMessage(messages.destinationNetwork)}
                 options={(availableNetworks ?? []).map((n) => ({
-                  label: n.label,
-                  value: n.chainport_network_id.toString(),
+                  label: (
+                    <HStack>
+                      <Image
+                        src={n.network.network_icon}
+                        alt={n.network.label}
+                        width="24"
+                        height="24"
+                      />
+                      <ItemText>{n.network.label}</ItemText>
+                    </HStack>
+                  ),
+                  value: n.network.chainport_network_id.toString(),
                 }))}
                 renderChildren={(children) => (
                   <HStack>
                     {selectedNetwork && (
                       <ChakraImage
-                        src={selectedNetwork.network_icon}
+                        src={selectedNetwork.network.network_icon}
                         boxSize="24px"
                       />
                     )}

--- a/renderer/components/BridgeAssetsForm/BridgeConfirmationModal/BridgeConfirmationModal.tsx
+++ b/renderer/components/BridgeAssetsForm/BridgeConfirmationModal/BridgeConfirmationModal.tsx
@@ -19,7 +19,6 @@ import { trpcReact, TRPCRouterOutputs } from "@/providers/TRPCProvider";
 import { PillButton } from "@/ui/PillButton/PillButton";
 import { CurrencyUtils } from "@/utils/currency";
 import { formatOre } from "@/utils/ironUtils";
-import { IRON_ID, IRON_SYMBOL } from "@shared/constants";
 
 import { StepIdle } from "./StepIdle";
 import { AssetOptionType } from "../../AssetAmountInput/utils";
@@ -115,7 +114,7 @@ export function BridgeConfirmationModal({
       amount: convertedAmount.toString(),
       assetId: chainportToken.web3_address,
       to: formData.targetAddress,
-      selectedNetwork: targetNetwork.chainport_network_id,
+      selectedNetwork: targetNetwork.network.chainport_network_id,
     },
     {
       retry: false,
@@ -190,17 +189,12 @@ export function BridgeConfirmationModal({
       chainportToken.decimals,
     );
 
-    return `${convertedAmount} ${
-      chainportToken.web3_address === IRON_ID
-        ? IRON_SYMBOL
-        : chainportToken.symbol
-    }`;
+    return `${convertedAmount} ${targetNetwork.token.symbol}`;
   }, [
     isTransactionDetailsLoading,
     txDetails,
+    targetNetwork.token.symbol,
     chainportToken.decimals,
-    chainportToken.symbol,
-    chainportToken.web3_address,
   ]);
 
   const chainportGasFee = useMemo(() => {
@@ -279,10 +273,12 @@ export function BridgeConfirmationModal({
           {isSubmitIdle && (
             <StepIdle
               fromAccount={formData.fromAccount}
-              targetNetwork={targetNetwork.label}
-              targetNetworkIcon={targetNetwork.network_icon}
+              targetNetwork={targetNetwork.network.label}
+              targetNetworkIcon={targetNetwork.network.network_icon}
               amountSending={amountToSend}
+              amountSendingIcon={selectedAsset.asset.verification.logoURI}
               amountReceiving={amountToReceive}
+              amountReceivingIcon={targetNetwork.token.token_image}
               targetAddress={formData.targetAddress}
               chainportGasFee={chainportGasFee}
               chainportBridgeFee={chainportBridgeFee}

--- a/renderer/components/BridgeAssetsForm/BridgeConfirmationModal/StepIdle.tsx
+++ b/renderer/components/BridgeAssetsForm/BridgeConfirmationModal/StepIdle.tsx
@@ -85,7 +85,9 @@ type Props = {
   targetNetwork: string;
   targetNetworkIcon: string;
   amountSending: ReactNode;
+  amountSendingIcon: string | undefined;
   amountReceiving: ReactNode;
+  amountReceivingIcon: string;
   targetAddress: string;
   chainportGasFee: ReactNode;
   chainportBridgeFee: ReactNode;
@@ -103,7 +105,9 @@ export function StepIdle({
   targetNetwork,
   targetNetworkIcon,
   amountSending,
+  amountSendingIcon,
   amountReceiving,
+  amountReceivingIcon,
   targetAddress,
   chainportGasFee,
   chainportBridgeFee,
@@ -200,7 +204,7 @@ export function StepIdle({
             <LineItem
               label={formatMessage(messages.sendingLabel)}
               content={amountSending}
-              icon={ironfishIcon}
+              icon={amountSendingIcon ?? ironfishIcon}
             />
           </GridItem>
           <GridItem>
@@ -208,7 +212,7 @@ export function StepIdle({
               label={formatMessage(messages.receivingLabel)}
               content={amountReceiving}
               tooltip={formatMessage(messages.receivingTooltip)}
-              icon={chainportIcon}
+              icon={amountReceivingIcon}
             />
           </GridItem>
         </Grid>

--- a/shared/chainport.ts
+++ b/shared/chainport.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type {
   ChainportNetwork,
   ChainportToken,
+  ChainportTokenWithNetwork,
 } from "../main/api/chainport/vendor/types";
 
 type ZodTypeValue<Value, ZodType extends z.ZodType> = undefined extends Value
@@ -57,7 +58,12 @@ const chainportTokenSchema = createSchema<ChainportToken>({
 });
 
 const TokensApiResponseSchema = z.array(chainportTokenSchema);
-const TokenPathsApiResponseSchema = z.array(chainportNetworkSchema);
+const TokenPathsApiResponseSchema = z.array(
+  createSchema<ChainportTokenWithNetwork>({
+    token: chainportTokenSchema,
+    network: chainportNetworkSchema,
+  }),
+);
 
 export function assertTokensApiResponse(data: unknown): ChainportToken[] {
   try {
@@ -70,7 +76,9 @@ ${err}
   }
 }
 
-export function assertTokenPathsApiResponse(data: unknown): ChainportNetwork[] {
+export function assertTokenPathsApiResponse(
+  data: unknown,
+): ChainportTokenWithNetwork[] {
   try {
     return TokenPathsApiResponseSchema.parse(data);
   } catch (err) {


### PR DESCRIPTION
Adds verified asset icons to the asset dropdown, network icons to the network dropdown, and uses the token's name on the destination network on the confirmation modal.

<img width="699" alt="image" src="https://github.com/user-attachments/assets/11aba46e-da01-4d69-949f-e088988baca7">

<img width="699" alt="image" src="https://github.com/user-attachments/assets/440e1cea-f82c-41bb-8a79-e72da778feff">

<img width="589" alt="image" src="https://github.com/user-attachments/assets/1fca6203-f158-43d1-a3cc-15fdf9f06e72">


Fixes IFL-3069
