### PR TITLE
Makes ui of "to" field on send form clearer on who recipient is

### DIFF
--- a/renderer/components/SendAssetsForm/SendAssetsForm.tsx
+++ b/renderer/components/SendAssetsForm/SendAssetsForm.tsx
@@ -258,6 +258,13 @@ export function SendAssetsFormContent({
     return [...(contacts ?? []), ...(accounts ?? [])];
   }, [contactsData, allAccountsData]);
 
+  const accountNameInAddressBook = useMemo(() => {
+    const fullContact = formattedContacts.find(
+      (contact) => contact.value === toAccountValue,
+    );
+    return fullContact?.label.main;
+  }, [formattedContacts, toAccountValue]);
+
   return (
     <>
       {syncingMessage}
@@ -312,7 +319,9 @@ export function SendAssetsFormContent({
 
           <Combobox
             {...register("toAccount")}
-            label={formatMessage(messages.toLabel)}
+            label={`${formatMessage(messages.toLabel)}${
+              accountNameInAddressBook ? ": " + accountNameInAddressBook : ""
+            }`}
             error={errors.toAccount?.message}
             options={formattedContacts}
             value={toAccountValue}

--- a/renderer/ui/Forms/Combobox/Combobox.tsx
+++ b/renderer/ui/Forms/Combobox/Combobox.tsx
@@ -137,6 +137,9 @@ export const Combobox = forwardRef<HTMLInputElement, Props>(function Combobox(
               type="button"
               display="block"
               w="100%"
+              background={
+                option.value === value ? COLORS.GRAY_LIGHT : "transparent"
+              }
               textAlign="left"
               onMouseDown={(e) => {
                 e.preventDefault();


### PR DESCRIPTION
Fixes IFL-2579

The initial ask was to replace the input value with the account name if they existed in the address book but to save a bit of complexity I think this resolves most of the problem while not having to alter the input value

Changes:
- When an account is selected from the address book it changes the `to` label to be `to: {account name}`
- Selected account is given a gray background in the dropdown menu

<img width="560" alt="image" src="https://github.com/user-attachments/assets/5d6f8d5c-72b5-46c7-8c6f-1a3b41259dd8">
