### PR TITLE
Trims identities in multisig step

### DIFF
--- a/renderer/components/SendMultisigLedgerAssetsFlow/Steps/CollectIdentities.tsx
+++ b/renderer/components/SendMultisigLedgerAssetsFlow/Steps/CollectIdentities.tsx
@@ -69,7 +69,17 @@ export function CollectIdentities({
           height="60px"
           px={8}
           onClick={() => {
-            onSubmit([myIdentity, ...otherIdentities]);
+            // Trim whitespace from all identities
+            const allIdentities = otherIdentities.reduce(
+              (acc, identity) => {
+                if (identity) {
+                  acc.push(identity.trim());
+                }
+                return acc;
+              },
+              [myIdentity],
+            );
+            onSubmit(allIdentities);
           }}
         >
           Next


### PR DESCRIPTION
The CLI outputs a trailing whitespace when showing an identity which makes it super easy to add an extra white space at the end when copy/pasting an identity. This tripped me up for a while when trying to get through the process so here is a small fix to trim the white space