### PR TITLE
Set account head when creating a new wallet

### DIFF
--- a/main/api/accounts/handleCreateAccount.ts
+++ b/main/api/accounts/handleCreateAccount.ts
@@ -1,13 +1,19 @@
-import { AccountFormat } from "@ironfish/sdk";
+import { AccountFormat, CreateAccountRequest } from "@ironfish/sdk";
 
 import { manager } from "../manager";
 
-export async function handleCreateAccount({ name }: { name: string }) {
+export async function handleCreateAccount({
+  name,
+  createdAt,
+  head,
+}: CreateAccountRequest) {
   const ironfish = await manager.getIronfish();
   const rpcClient = await ironfish.rpcClient();
 
   const createResponse = await rpcClient.wallet.createAccount({
     name,
+    createdAt,
+    head,
   });
 
   const exportResponse = await rpcClient.wallet.exportAccount({

--- a/main/api/accounts/index.ts
+++ b/main/api/accounts/index.ts
@@ -39,11 +39,21 @@ export const accountRouter = t.router({
     .input(
       z.object({
         name: z.string(),
+        createdAt: z.number().optional(),
+        head: z
+          .object({
+            sequence: z.number(),
+            hash: z.string(),
+          })
+          .optional(),
       }),
     )
     .mutation(async (opts) => {
       return handleCreateAccount(opts.input);
     }),
+  getExternalChainHead: t.procedure.query(async () =>
+    manager.getExternalChainHead(),
+  ),
   importAccount: t.procedure
     .input(handleImportAccountInputs)
     .mutation(async (opts) => {

--- a/main/api/accounts/utils/getExternalChainHead.ts
+++ b/main/api/accounts/utils/getExternalChainHead.ts
@@ -1,0 +1,114 @@
+import { GENESIS_BLOCK_SEQUENCE } from "@ironfish/sdk";
+import axios from "axios";
+
+const MAINNET_API_URL = `https://api.ironfish.network`;
+const TESTNET_API_URL = `https://testnet.api.ironfish.network`;
+const CONFIRMATION_BLOCKS = 20;
+
+type Block = { sequence: number; hash: string };
+
+// Try to get a head sequence to use for new account createdAt fields if the chain is not yet synced
+export async function getExternalChainHead(
+  networkId: number,
+): Promise<Block | undefined> {
+  const fromAPI = await getChainHeadWithConfirmation(networkId).catch(
+    () => undefined,
+  );
+
+  return fromAPI || getDefaultHead(networkId);
+}
+
+async function getChainHeadWithConfirmation(
+  networkId: number,
+): Promise<Block | undefined> {
+  const headFromAPI = await getChainHeadFromAPI(networkId).catch(
+    () => undefined,
+  );
+  if (!headFromAPI) {
+    return undefined;
+  }
+
+  const sequence = Math.max(
+    GENESIS_BLOCK_SEQUENCE,
+    headFromAPI.sequence - CONFIRMATION_BLOCKS,
+  );
+  return getBlockFromAPI(networkId, sequence).catch(() => undefined);
+}
+
+// Local block sequences in case network is unreachable
+function getDefaultHead(networkId: number): Block | undefined {
+  switch (networkId) {
+    case 0:
+      return {
+        sequence: 740000,
+        hash: "00000419de21cb51eeea7b002c89e630f0b326525e99a6595b4c87442fd7bfa5",
+      };
+    case 1:
+      return {
+        sequence: 806900,
+        hash: "0000000000016a6993058e7459fff9f1413f14c09483612d511e5e86894803b7",
+      };
+    default:
+      return undefined;
+  }
+}
+
+async function getChainHeadFromAPI(networkId: number): Promise<Block> {
+  const apiURL = getAPIUrl(networkId);
+  if (!apiURL) {
+    throw new Error(
+      `Manifest url for the snapshots are not available for network ID ${networkId}`,
+    );
+  }
+
+  const headBlock = (
+    await axios.get<{ sequence: number; hash: string }>(
+      `${apiURL}/blocks/head`,
+      {
+        timeout: 5000,
+      },
+    )
+  ).data;
+
+  return {
+    sequence: headBlock.sequence,
+    hash: headBlock.hash,
+  };
+}
+
+async function getBlockFromAPI(
+  networkId: number,
+  sequence: number,
+): Promise<Block | undefined> {
+  const apiURL = getAPIUrl(networkId);
+  if (!apiURL) {
+    throw new Error(
+      `Manifest url for the snapshots are not available for network ID ${networkId}`,
+    );
+  }
+
+  const head = (
+    await axios.get<{ sequence: number; hash: string }>(
+      `${apiURL}/blocks/find?sequence=${sequence}&with_transactions=false`,
+      {
+        timeout: 5000,
+      },
+    )
+  ).data;
+
+  return {
+    sequence: head.sequence,
+    hash: head.hash,
+  };
+}
+
+const getAPIUrl = (networkId: number): string | null => {
+  switch (networkId) {
+    case 0:
+      return TESTNET_API_URL;
+    case 1:
+      return MAINNET_API_URL;
+    default:
+      return null;
+  }
+};

--- a/main/api/manager.ts
+++ b/main/api/manager.ts
@@ -1,5 +1,6 @@
 import { RpcClient } from "@ironfish/sdk";
 
+import { getExternalChainHead } from "./accounts/utils/getExternalChainHead";
 import { Ironfish } from "./ironfish/Ironfish";
 import { userSettingsStore } from "../stores/userSettingsStore";
 
@@ -11,6 +12,7 @@ export type InitialState =
 
 export class Manager {
   private _ironfish: Ironfish | null = null;
+  private _externalChainHead?: { sequence: number; hash: string };
 
   async getIronfish(): Promise<Ironfish> {
     if (this._ironfish) return this._ironfish;
@@ -21,6 +23,13 @@ export class Manager {
       networkId,
     });
     return this._ironfish;
+  }
+
+  async getExternalChainHead(): Promise<
+    { sequence: number; hash: string } | undefined
+  > {
+    const networkId = await userSettingsStore.getSetting("networkId");
+    return getExternalChainHead(networkId);
   }
 
   async shouldDownloadSnapshot(): Promise<boolean> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@ironfish/rust-nodejs": "2.7.0",
-        "@ironfish/sdk": "2.8.1",
+        "@ironfish/sdk": "2.9.0",
         "@ledgerhq/errors": "6.19.1",
         "@ledgerhq/hw-transport-node-hid": "6.29.5",
         "@zondax/ledger-ironfish": "1.0.0",
@@ -4647,15 +4647,15 @@
       }
     },
     "node_modules/@ironfish/sdk": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@ironfish/sdk/-/sdk-2.8.1.tgz",
-      "integrity": "sha512-R4XTXeLZCWIbWdrnGq5v+ua0+e9FAN5jK22OnxHOWUitq2f+JPyc1E7lRjLg4iNyU56Vc2FJzBEfQ0ztpjhbbg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/sdk/-/sdk-2.9.0.tgz",
+      "integrity": "sha512-yCLprHrkEShS52R33N0IFti54p0mdLpDPGR2AZ0P1UFzmi+xMsjLGSRx3088RMVVjY3ZbxDr+fYbHI3gj6MfoA==",
       "dependencies": {
         "@ethersproject/bignumber": "5.7.0",
         "@fast-csv/format": "4.3.5",
-        "@ironfish/rust-nodejs": "2.7.0",
+        "@ironfish/rust-nodejs": "2.8.0",
         "@napi-rs/blake-hash": "1.3.3",
-        "axios": "1.7.2",
+        "axios": "1.7.7",
         "bech32": "2.0.0",
         "blru": "0.1.6",
         "buffer": "6.0.3",
@@ -4679,17 +4679,139 @@
         "sqlite": "4.0.23",
         "sqlite3": "5.1.6",
         "uuid": "8.3.2",
-        "ws": "8.12.1",
+        "ws": "8.18.0",
         "yup": "0.29.3"
       },
       "engines": {
         "node": ">=18"
       }
     },
+    "node_modules/@ironfish/sdk/node_modules/@ironfish/rust-nodejs": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs/-/rust-nodejs-2.8.0.tgz",
+      "integrity": "sha512-U//4E4iBMY5EUa3hpFOwvV7wZ+dVqGmJjtCsD2y3ZpSE7PFFSz03/vlwh1G3O3Gm4W4LMDuW2FBhEndXzaAG0A==",
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@ironfish/rust-nodejs-darwin-arm64": "2.8.0",
+        "@ironfish/rust-nodejs-darwin-x64": "2.8.0",
+        "@ironfish/rust-nodejs-linux-arm64-gnu": "2.8.0",
+        "@ironfish/rust-nodejs-linux-arm64-musl": "2.8.0",
+        "@ironfish/rust-nodejs-linux-x64-gnu": "2.8.0",
+        "@ironfish/rust-nodejs-linux-x64-musl": "2.8.0",
+        "@ironfish/rust-nodejs-win32-x64-msvc": "2.8.0"
+      }
+    },
+    "node_modules/@ironfish/sdk/node_modules/@ironfish/rust-nodejs-darwin-arm64": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-arm64/-/rust-nodejs-darwin-arm64-2.8.0.tgz",
+      "integrity": "sha512-RDDoMyusB+H8nkxRHFIIAy/W2gZi1HqpzVqj736boc4eZrOOxllpt8rxoHWJc2fW60AZ8M+VxgkYTGW7f1Vbng==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@ironfish/sdk/node_modules/@ironfish/rust-nodejs-darwin-x64": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-x64/-/rust-nodejs-darwin-x64-2.8.0.tgz",
+      "integrity": "sha512-njHRG1Y6icAX9Q4kjDZnO2AlDwrHYjKt6AY0OhFM7Cz8jspLjDN/mn5/TKcFV+cSt5jrQKb8RL9tUrTDLVLVuA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@ironfish/sdk/node_modules/@ironfish/rust-nodejs-linux-arm64-gnu": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-gnu/-/rust-nodejs-linux-arm64-gnu-2.8.0.tgz",
+      "integrity": "sha512-q0LZWgG1wsOvihdAFQ1r8WtI1WpOqI18lJ0UAS4BuCYnyfaOerHNfhezuoL90n0U99U2YzGWEdJzr0DAG+hMPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@ironfish/sdk/node_modules/@ironfish/rust-nodejs-linux-arm64-musl": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-musl/-/rust-nodejs-linux-arm64-musl-2.8.0.tgz",
+      "integrity": "sha512-s6uPrD10vrW15Axl2a3c9bdBODt9It0qfJaFhwAPVcPetxrgoYEd1Qh0Nz/dEqMniJdhEKeckNgvyGySveB0Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@ironfish/sdk/node_modules/@ironfish/rust-nodejs-linux-x64-gnu": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-gnu/-/rust-nodejs-linux-x64-gnu-2.8.0.tgz",
+      "integrity": "sha512-7X2o1lXjvmAyYkF96U2GEKgaZ1KDKYGhGY5ApJq6W6DuMxSHbFheQZ8V/ea18eBp1ycGcVBM5IGx9prJLdzxig==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@ironfish/sdk/node_modules/@ironfish/rust-nodejs-linux-x64-musl": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-musl/-/rust-nodejs-linux-x64-musl-2.8.0.tgz",
+      "integrity": "sha512-COKQKNseKYq+MktLYjZG/9XXPWQsIAoQ14rbR+KrOQk1LjxGrkC0ikYJCZcJUqVXzL9feLja1ggN675io3VRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@ironfish/sdk/node_modules/@ironfish/rust-nodejs-win32-x64-msvc": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-win32-x64-msvc/-/rust-nodejs-win32-x64-msvc-2.8.0.tgz",
+      "integrity": "sha512-lVLq/Rt/jlXC6FPxVyS8GfF6VDtexOmwBBZi7Rps1sRlsz6nRhtulAsI35qD2FcwC59XOhpDuckgE5/KyEsDbw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@ironfish/sdk/node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -17464,9 +17586,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
-      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "@ironfish/sdk": "2.8.1",
+    "@ironfish/sdk": "2.9.0",
     "@ironfish/rust-nodejs": "2.7.0",
     "@ledgerhq/errors": "6.19.1",
     "@ledgerhq/hw-transport-node-hid": "6.29.5",

--- a/renderer/components/OnboardingFlow/CreateImportAccount/CreateImportAccount.tsx
+++ b/renderer/components/OnboardingFlow/CreateImportAccount/CreateImportAccount.tsx
@@ -2,6 +2,7 @@ import { Box, Heading, HStack, Text } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import { defineMessages, useIntl } from "react-intl";
 
+import { trpcReact } from "@/providers/TRPCProvider";
 import { COLORS } from "@/ui/colors";
 import { PillButton } from "@/ui/PillButton/PillButton";
 import { ShadowCard } from "@/ui/ShadowCard/ShadowCard";
@@ -28,6 +29,12 @@ const messages = defineMessages({
 export function CreateImportAccount() {
   const router = useRouter();
   const { formatMessage } = useIntl();
+
+  // Initiate query and cache the data for a subsequent call when creating the account
+  trpcReact.getExternalChainHead.useQuery(undefined, {
+    cacheTime: 1000 * 60 * 10,
+    staleTime: 1000 * 60 * 10,
+  });
 
   return (
     <Box>


### PR DESCRIPTION
When a new wallet is created on initial startup it never sets the account birthday or head value so the account is forced to sync the whole chain. This sets both the birthday and head from the ironfish API (or alternatively from a backup hardcoded sequence) so the account can skip syncing blocks unnecessarily.