### PR TITLE
Pass through API error messages when bridging

### DIFF
--- a/main/api/chainport/vendor/requests.ts
+++ b/main/api/chainport/vendor/requests.ts
@@ -85,11 +85,11 @@ const makeChainportRequest = async <T extends object>(
     })
     .catch((error) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const chainportError = error.response?.data?.error?.description as string;
-      if (chainportError) {
-        throw new Error(chainportError);
+      const apiError = error.response?.data?.message as string;
+      if (apiError) {
+        throw new Error("Chainport error: " + apiError);
       } else {
-        throw new Error("Chainport error - " + error);
+        throw new Error("Chainport error: " + error);
       }
     });
 


### PR DESCRIPTION
The bridge API wasn't returning errors from Chainport, instead throwing a 502. Now with this PR: https://github.com/iron-fish/ironfish-api/pull/1798 The API will return error messages, but this PR is needed so the node app parses the API error correctly.

<img width="663" alt="image" src="https://github.com/user-attachments/assets/e7baf66c-aff5-4eba-b840-5b3134a5cc17" />

