### PR TITLE
Bump Iron Fish SDK to 2.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@ironfish/rust-nodejs": "2.7.0",
-        "@ironfish/sdk": "2.9.0",
+        "@ironfish/rust-nodejs": "2.9.0",
+        "@ironfish/sdk": "2.10.0",
         "@ledgerhq/errors": "6.19.1",
         "@ledgerhq/hw-transport-node-hid": "6.29.5",
         "@zondax/ledger-ironfish": "1.0.0",
@@ -4525,26 +4525,26 @@
       "dev": true
     },
     "node_modules/@ironfish/rust-nodejs": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs/-/rust-nodejs-2.7.0.tgz",
-      "integrity": "sha512-jJRblJa3XxIiPCnPHvJhXKoB+QMbAoHqsHsIPTRPQIGk9cFuAhoFpgQT0RIw103JjXMNSwYOXOi3iPpwGxzMZQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs/-/rust-nodejs-2.9.0.tgz",
+      "integrity": "sha512-uZG+awPA3Mz730RH1+wRojYdG4D9B4e4PuAsQrGaUIuLFHXM7Ab70SNLhnCG8/0egJYXEWl74WyJO47qWh8s+w==",
       "engines": {
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@ironfish/rust-nodejs-darwin-arm64": "2.7.0",
-        "@ironfish/rust-nodejs-darwin-x64": "2.7.0",
-        "@ironfish/rust-nodejs-linux-arm64-gnu": "2.7.0",
-        "@ironfish/rust-nodejs-linux-arm64-musl": "2.7.0",
-        "@ironfish/rust-nodejs-linux-x64-gnu": "2.7.0",
-        "@ironfish/rust-nodejs-linux-x64-musl": "2.7.0",
-        "@ironfish/rust-nodejs-win32-x64-msvc": "2.7.0"
+        "@ironfish/rust-nodejs-darwin-arm64": "2.9.0",
+        "@ironfish/rust-nodejs-darwin-x64": "2.9.0",
+        "@ironfish/rust-nodejs-linux-arm64-gnu": "2.9.0",
+        "@ironfish/rust-nodejs-linux-arm64-musl": "2.9.0",
+        "@ironfish/rust-nodejs-linux-x64-gnu": "2.9.0",
+        "@ironfish/rust-nodejs-linux-x64-musl": "2.9.0",
+        "@ironfish/rust-nodejs-win32-x64-msvc": "2.9.0"
       }
     },
     "node_modules/@ironfish/rust-nodejs-darwin-arm64": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-arm64/-/rust-nodejs-darwin-arm64-2.7.0.tgz",
-      "integrity": "sha512-Ct60f7lh6tVOReun/LZKRdEZ9jZuXYIz/sHNbxc5DAAcmi3L+lZVwASm6tfXu2FrU9NtTjA2Fke7n8UJqq5feQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-arm64/-/rust-nodejs-darwin-arm64-2.9.0.tgz",
+      "integrity": "sha512-s+ENuzTSw5aXrT5NTMgqV/++YLn/SPihytt7J3st1w078cz81ts7eCp66GRMEby6AmSDYlI29gnFUd8AEh9FyA==",
       "cpu": [
         "arm64"
       ],
@@ -4557,9 +4557,9 @@
       }
     },
     "node_modules/@ironfish/rust-nodejs-darwin-x64": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-x64/-/rust-nodejs-darwin-x64-2.7.0.tgz",
-      "integrity": "sha512-TOWeYcwSc/tpj95BuRND0fg0BbuxSL9bl67VvAD6buQxsQcHstTIBfsKtd8wBcF8VHMTCz81MqAgycMmClufCA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-x64/-/rust-nodejs-darwin-x64-2.9.0.tgz",
+      "integrity": "sha512-wcEeySiptG6x+gYepAeeW/Btwym13PqF1ylIZQdARve0lyMuBgFKtgwZ/dq1mYsDK3PkQsZe94ioCsCPp/3ffQ==",
       "cpu": [
         "x64"
       ],
@@ -4572,9 +4572,9 @@
       }
     },
     "node_modules/@ironfish/rust-nodejs-linux-arm64-gnu": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-gnu/-/rust-nodejs-linux-arm64-gnu-2.7.0.tgz",
-      "integrity": "sha512-srWt/PxQhPihIIXu1vgq4wtiPRj0B9n1ORMnw+TcmcUOFWvHFL0mkVKSbl1qnpaeV1SWIkRXpn65vfIUF5/k1A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-gnu/-/rust-nodejs-linux-arm64-gnu-2.9.0.tgz",
+      "integrity": "sha512-CHl31hkZf865ifmQt8KAolihgwwMxZ4h/odEHLHUAjfziYf84gZSlkVGwGPD6z/G9+xSnUQJlw6zq72M/UR8Xg==",
       "cpu": [
         "arm64"
       ],
@@ -4587,9 +4587,9 @@
       }
     },
     "node_modules/@ironfish/rust-nodejs-linux-arm64-musl": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-musl/-/rust-nodejs-linux-arm64-musl-2.7.0.tgz",
-      "integrity": "sha512-k1eIZ1eDszKkGnVJn9LME609EBqRdIwpiM5/Akeq+MA26IjV8HwgkNtU0myRfqfdg8Q3qHwqGoXD9ICZEnXlsw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-musl/-/rust-nodejs-linux-arm64-musl-2.9.0.tgz",
+      "integrity": "sha512-0dAwPdHJQBkFn/OnvD9eyMuCaySQ3vwY+1hH3oG/Ws7v906V0lYGhdqv5oKhKfw81wzRabrHeLTQ1NUp2CZQ0A==",
       "cpu": [
         "arm64"
       ],
@@ -4602,9 +4602,9 @@
       }
     },
     "node_modules/@ironfish/rust-nodejs-linux-x64-gnu": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-gnu/-/rust-nodejs-linux-x64-gnu-2.7.0.tgz",
-      "integrity": "sha512-RTe+UwwGjVhM9n7OH89lUr1TJ91vKu68rwrpDMMI4deylf9tPv5S0yFeKE16yZnuifzQYq6Ayvg2U4B/ZU8E3A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-gnu/-/rust-nodejs-linux-x64-gnu-2.9.0.tgz",
+      "integrity": "sha512-SObtiu7ZX3Yj23Lv/JL9CIvJWWdAQHnemNNY4xCL+Bc12caU567tADNew1JUTl9mFOkkCbvpTlRQMMKjDz7vBQ==",
       "cpu": [
         "x64"
       ],
@@ -4617,9 +4617,9 @@
       }
     },
     "node_modules/@ironfish/rust-nodejs-linux-x64-musl": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-musl/-/rust-nodejs-linux-x64-musl-2.7.0.tgz",
-      "integrity": "sha512-sbMvHXG6XsAptS3Z60qwiK5w4m4Rumptcs2k5hFQyuVFOZ9Efn33L8nZbpOGjuOhfOGFEifjcA3CTjjS7wtOnw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-musl/-/rust-nodejs-linux-x64-musl-2.9.0.tgz",
+      "integrity": "sha512-fGgIKgxEqWnp5+Y3eO5WYRUPG7PxmPYSzJbs4CEkpEI8uksop2pRI+d2Tt8aOz1rcU4wj2prfYd/bGLoovB1PA==",
       "cpu": [
         "x64"
       ],
@@ -4632,9 +4632,9 @@
       }
     },
     "node_modules/@ironfish/rust-nodejs-win32-x64-msvc": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-win32-x64-msvc/-/rust-nodejs-win32-x64-msvc-2.7.0.tgz",
-      "integrity": "sha512-2WYKHhjYI4P0qq9vdgp+WD3mlmYWpkYbDjPElhlTttxRsRs2QGY9KV2BRAqc+Y81Ci7uYDarj8mmjBOORwmq+A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-win32-x64-msvc/-/rust-nodejs-win32-x64-msvc-2.9.0.tgz",
+      "integrity": "sha512-6iD9fglFQ4AGJELRB6FPhxHYf6t0la3pA9/FWMprVhtNCXGGk2P+5Z5FuAjrmFqmNRIxQL5q96JCNvdXH2fMQw==",
       "cpu": [
         "x64"
       ],
@@ -4647,13 +4647,13 @@
       }
     },
     "node_modules/@ironfish/sdk": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/sdk/-/sdk-2.9.0.tgz",
-      "integrity": "sha512-yCLprHrkEShS52R33N0IFti54p0mdLpDPGR2AZ0P1UFzmi+xMsjLGSRx3088RMVVjY3ZbxDr+fYbHI3gj6MfoA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@ironfish/sdk/-/sdk-2.10.0.tgz",
+      "integrity": "sha512-6FDGCG+PlVB5sMo9dA29kju5Kc4YZ7Bqm0+hfPJ2aN3T14S0GkjgSieRakauWOlAXv4xyDIxVI9Iw4N0Wy8ThA==",
       "dependencies": {
         "@ethersproject/bignumber": "5.7.0",
         "@fast-csv/format": "4.3.5",
-        "@ironfish/rust-nodejs": "2.8.0",
+        "@ironfish/rust-nodejs": "2.9.0",
         "@napi-rs/blake-hash": "1.3.3",
         "axios": "1.7.7",
         "bech32": "2.0.0",
@@ -4684,128 +4684,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@ironfish/sdk/node_modules/@ironfish/rust-nodejs": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs/-/rust-nodejs-2.8.0.tgz",
-      "integrity": "sha512-U//4E4iBMY5EUa3hpFOwvV7wZ+dVqGmJjtCsD2y3ZpSE7PFFSz03/vlwh1G3O3Gm4W4LMDuW2FBhEndXzaAG0A==",
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@ironfish/rust-nodejs-darwin-arm64": "2.8.0",
-        "@ironfish/rust-nodejs-darwin-x64": "2.8.0",
-        "@ironfish/rust-nodejs-linux-arm64-gnu": "2.8.0",
-        "@ironfish/rust-nodejs-linux-arm64-musl": "2.8.0",
-        "@ironfish/rust-nodejs-linux-x64-gnu": "2.8.0",
-        "@ironfish/rust-nodejs-linux-x64-musl": "2.8.0",
-        "@ironfish/rust-nodejs-win32-x64-msvc": "2.8.0"
-      }
-    },
-    "node_modules/@ironfish/sdk/node_modules/@ironfish/rust-nodejs-darwin-arm64": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-arm64/-/rust-nodejs-darwin-arm64-2.8.0.tgz",
-      "integrity": "sha512-RDDoMyusB+H8nkxRHFIIAy/W2gZi1HqpzVqj736boc4eZrOOxllpt8rxoHWJc2fW60AZ8M+VxgkYTGW7f1Vbng==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@ironfish/sdk/node_modules/@ironfish/rust-nodejs-darwin-x64": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-darwin-x64/-/rust-nodejs-darwin-x64-2.8.0.tgz",
-      "integrity": "sha512-njHRG1Y6icAX9Q4kjDZnO2AlDwrHYjKt6AY0OhFM7Cz8jspLjDN/mn5/TKcFV+cSt5jrQKb8RL9tUrTDLVLVuA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@ironfish/sdk/node_modules/@ironfish/rust-nodejs-linux-arm64-gnu": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-gnu/-/rust-nodejs-linux-arm64-gnu-2.8.0.tgz",
-      "integrity": "sha512-q0LZWgG1wsOvihdAFQ1r8WtI1WpOqI18lJ0UAS4BuCYnyfaOerHNfhezuoL90n0U99U2YzGWEdJzr0DAG+hMPg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@ironfish/sdk/node_modules/@ironfish/rust-nodejs-linux-arm64-musl": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-arm64-musl/-/rust-nodejs-linux-arm64-musl-2.8.0.tgz",
-      "integrity": "sha512-s6uPrD10vrW15Axl2a3c9bdBODt9It0qfJaFhwAPVcPetxrgoYEd1Qh0Nz/dEqMniJdhEKeckNgvyGySveB0Yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@ironfish/sdk/node_modules/@ironfish/rust-nodejs-linux-x64-gnu": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-gnu/-/rust-nodejs-linux-x64-gnu-2.8.0.tgz",
-      "integrity": "sha512-7X2o1lXjvmAyYkF96U2GEKgaZ1KDKYGhGY5ApJq6W6DuMxSHbFheQZ8V/ea18eBp1ycGcVBM5IGx9prJLdzxig==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@ironfish/sdk/node_modules/@ironfish/rust-nodejs-linux-x64-musl": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-linux-x64-musl/-/rust-nodejs-linux-x64-musl-2.8.0.tgz",
-      "integrity": "sha512-COKQKNseKYq+MktLYjZG/9XXPWQsIAoQ14rbR+KrOQk1LjxGrkC0ikYJCZcJUqVXzL9feLja1ggN675io3VRcg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@ironfish/sdk/node_modules/@ironfish/rust-nodejs-win32-x64-msvc": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@ironfish/rust-nodejs-win32-x64-msvc/-/rust-nodejs-win32-x64-msvc-2.8.0.tgz",
-      "integrity": "sha512-lVLq/Rt/jlXC6FPxVyS8GfF6VDtexOmwBBZi7Rps1sRlsz6nRhtulAsI35qD2FcwC59XOhpDuckgE5/KyEsDbw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/@ironfish/sdk/node_modules/axios": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "@ironfish/sdk": "2.9.0",
-    "@ironfish/rust-nodejs": "2.7.0",
+    "@ironfish/sdk": "2.10.0",
+    "@ironfish/rust-nodejs": "2.9.0",
     "@ledgerhq/errors": "6.19.1",
     "@ledgerhq/hw-transport-node-hid": "6.29.5",
     "@zondax/ledger-ironfish": "1.0.0",


### PR DESCRIPTION
Also bumps the rust-nodejs to 2.9.0 to match.
