### PR TITLE
Update Electron to v34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "date-fns": "^2.30.0",
         "date-fns-tz": "^2.0.0",
         "dotenv": "^16.3.1",
-        "electron": "32.0.1",
+        "electron": "34.0.0",
         "electron-builder": "^24.6.4",
         "electron-log": "5.0.0",
         "electron-store": "^8.1.0",
@@ -9186,9 +9186,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "32.0.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-32.0.1.tgz",
-      "integrity": "sha512-5Hd5Jaf9niYVR2hZxoRd3gOrcxPOxQV1XPV5WaoSfT9jLJHFadhlKtuSDIk3U6rQZke+aC7GqPPAv55nWFCMsA==",
+      "version": "34.0.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-34.0.0.tgz",
+      "integrity": "sha512-fpaPb0lifoUJ6UJa4Lk8/0B2Ku/xDZWdc1Gkj67jbygTCrvSon0qquju6Ltx1Kz23GRqqlIHXiy9EvrjpY7/Wg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "date-fns": "^2.30.0",
     "date-fns-tz": "^2.0.0",
     "dotenv": "^16.3.1",
-    "electron": "32.0.1",
+    "electron": "34.0.0",
     "electron-builder": "^24.6.4",
     "electron-log": "5.0.0",
     "electron-store": "^8.1.0",


### PR DESCRIPTION
Here are the changelogs:

* 34: https://www.electronjs.org/blog/electron-34-0#breaking-changes
* 33: https://www.electronjs.org/blog/electron-33-0#breaking-changes

I don't see any breaking changes here that would affect us. Tested that I can still sync the node and connect via WebRTC.

