### PR TITLE
Fix logging to use electron-log

### DIFF
--- a/main/api/accounts/handleImportAccount.ts
+++ b/main/api/accounts/handleImportAccount.ts
@@ -1,4 +1,4 @@
-import log from "electron-log";
+import log from "electron-log/main";
 import * as z from "zod";
 
 import { manager } from "../manager";

--- a/main/api/chainport/index.ts
+++ b/main/api/chainport/index.ts
@@ -1,3 +1,4 @@
+import log from "electron-log/main";
 import { z } from "zod";
 
 import {
@@ -16,7 +17,6 @@ import {
   assertTokenPathsApiResponse,
   assertTokensApiResponse,
 } from "../../../shared/chainport";
-import { logger } from "../ironfish/logger";
 import { manager } from "../manager";
 import { t } from "../trpc";
 
@@ -38,7 +38,7 @@ export const chainportRouter = t.router({
         ),
       };
     } catch (err) {
-      logger.error(`Failed to fetch Chainport tokens data.
+      log.error(`Failed to fetch Chainport tokens data.
 
 ${err}
 `);
@@ -71,7 +71,7 @@ ${err}
             chainportTokenPaths: tokenPathsData,
           };
         } catch (err) {
-          logger.error(`Failed to fetch Chainport token paths data.
+          log.error(`Failed to fetch Chainport token paths data.
 
 ${err}
 `);
@@ -103,7 +103,7 @@ ${err}
           to,
         );
       } catch (err) {
-        logger.error(`Failed to fetch Chainport bridge transaction details.
+        log.error(`Failed to fetch Chainport bridge transaction details.
 
 ${err}
 `);

--- a/main/api/ironfish/Ironfish.ts
+++ b/main/api/ironfish/Ironfish.ts
@@ -12,7 +12,7 @@ import {
   RpcMemoryClient,
   getPackageFrom,
 } from "@ironfish/sdk";
-import log from "electron-log";
+import log from "electron-log/main";
 import { v4 as uuid } from "uuid";
 
 import { logger } from "./logger";

--- a/main/api/ironfish/index.ts
+++ b/main/api/ironfish/index.ts
@@ -1,5 +1,5 @@
 import { MAINNET, TESTNET } from "@ironfish/sdk";
-import log from "electron-log";
+import log from "electron-log/main";
 import { z } from "zod";
 
 import { manager } from "../manager";

--- a/main/api/ironfish/logger.ts
+++ b/main/api/ironfish/logger.ts
@@ -1,6 +1,6 @@
 import { Logger } from "@ironfish/sdk";
 import consola, { ConsolaReporterLogObject, LogLevel, logType } from "consola";
-import log from "electron-log";
+import log from "electron-log/main";
 
 const logPrefix = "[node]";
 

--- a/main/api/snapshot/snapshotManager.ts
+++ b/main/api/snapshot/snapshotManager.ts
@@ -1,7 +1,7 @@
 import fsAsync from "fs/promises";
 
 import { Event, FullNode, IronfishSdk, Meter } from "@ironfish/sdk";
-import log from "electron-log";
+import log from "electron-log/main";
 
 import {
   DownloadedSnapshot,

--- a/main/api/transactions/utils/formatTransactionsToNotes.ts
+++ b/main/api/transactions/utils/formatTransactionsToNotes.ts
@@ -1,5 +1,5 @@
 import { RpcAsset, RpcClient, RpcWalletTransaction } from "@ironfish/sdk";
-import log from "electron-log";
+import log from "electron-log/main";
 
 import { IRON_ID } from "@shared/constants";
 import { TransactionNote } from "@shared/types";

--- a/main/api/updates/index.ts
+++ b/main/api/updates/index.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { app } from "electron";
-import log from "electron-log";
+import log from "electron-log/main";
 import { clean, gt } from "semver";
 
 import { PartialGithubRelease } from "../../../shared/types";

--- a/main/api/utils/promiseQueue.ts
+++ b/main/api/utils/promiseQueue.ts
@@ -1,3 +1,5 @@
+import log from "electron-log/main";
+
 export class PromiseQueue {
   private queue: Array<() => Promise<unknown>> = [];
   private isProcessing = false;
@@ -12,7 +14,7 @@ export class PromiseQueue {
         try {
           await task();
         } catch (error) {
-          console.error("PromiseQueue task error:", error);
+          log.error("PromiseQueue task error:", error);
         }
       }
     }

--- a/main/api/window/index.ts
+++ b/main/api/window/index.ts
@@ -1,5 +1,5 @@
 import { app, dialog } from "electron";
-import log from "electron-log";
+import log from "electron-log/main";
 
 import { mainWindow } from "../../main-window";
 import { t } from "../trpc";

--- a/main/background.ts
+++ b/main/background.ts
@@ -6,7 +6,7 @@ import {
   Menu,
   MenuItem,
 } from "electron";
-import log from "electron-log";
+import log from "electron-log/main";
 import serve from "electron-serve";
 import { createIPCHandler } from "electron-trpc/main";
 
@@ -19,6 +19,7 @@ import { updater } from "./updater";
 
 const isProd: boolean = process.env.NODE_ENV === "production";
 
+log.initialize();
 log.transports.file.level = "info";
 
 if (isProd) {

--- a/main/main-window.ts
+++ b/main/main-window.ts
@@ -10,7 +10,7 @@ import {
   Rectangle,
   shell,
 } from "electron";
-import log from "electron-log";
+import log from "electron-log/main";
 import Store from "electron-store";
 
 const createWindow = (

--- a/main/updater.ts
+++ b/main/updater.ts
@@ -1,4 +1,4 @@
-import log from "electron-log";
+import log from "electron-log/main";
 import { autoUpdater } from "electron-updater";
 
 autoUpdater.logger = log;

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "dotenv": "^16.3.1",
         "electron": "32.0.1",
         "electron-builder": "^24.6.4",
-        "electron-log": "5.0.0",
+        "electron-log": "5.2.4",
         "electron-store": "^8.1.0",
         "electron-trpc": "^0.5.2",
         "electron-updater": "6.1.4",
@@ -9265,12 +9265,11 @@
       }
     },
     "node_modules/electron-log": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.0.0.tgz",
-      "integrity": "sha512-vB3akupmQvA8jAyNL9rULZtf6WoP8vsabjXsRtiqXS6/D37SwN/4LEyj4JD+9Bv6xoTcx/LrVnsIKEEWdq5ClQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.2.4.tgz",
+      "integrity": "sha512-iX12WXc5XAaKeHg2QpiFjVwL+S1NVHPFd3V5RXtCmKhpAzXsVQnR3UEc0LovM6p6NkUQxDWnkdkaam9FNUVmCA==",
       "dev": true,
       "engines": {
-        "electron": ">= 13",
         "node": ">= 14"
       }
     },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "dotenv": "^16.3.1",
     "electron": "32.0.1",
     "electron-builder": "^24.6.4",
-    "electron-log": "5.0.0",
+    "electron-log": "5.2.4",
     "electron-store": "^8.1.0",
     "electron-trpc": "^0.5.2",
     "electron-updater": "6.1.4",

--- a/renderer/components/AccountKeyExport/AccountKeyExport.tsx
+++ b/renderer/components/AccountKeyExport/AccountKeyExport.tsx
@@ -12,6 +12,7 @@ import {
   Switch,
 } from "@chakra-ui/react";
 import type { AccountFormat } from "@ironfish/sdk";
+import log from "electron-log/renderer";
 import { useEffect, useState } from "react";
 import { defineMessages, useIntl } from "react-intl";
 
@@ -124,7 +125,7 @@ export function AccountKeyExport({ accountName }: { accountName: string }) {
               })
               .then((c) => {
                 if (typeof c.account !== "string") {
-                  console.error("account should not be string");
+                  log.error("account should not be string");
                   return;
                 }
                 downloadString(

--- a/renderer/components/NoteRow/NoteRow.tsx
+++ b/renderer/components/NoteRow/NoteRow.tsx
@@ -5,6 +5,7 @@ import type {
   TransactionStatus,
   TransactionType,
 } from "@ironfish/sdk";
+import log from "electron-log/renderer";
 import { ReactNode, useMemo, useState } from "react";
 import { MessageDescriptor, useIntl } from "react-intl";
 
@@ -57,7 +58,7 @@ function getNoteStatusDisplay(
     }
 
     const unhandledType: never = type;
-    console.error("Unhandled transaction type", unhandledType);
+    log.error("Unhandled transaction type", unhandledType);
     return { icon: <ReceivedIcon />, message: messages.received };
   }
 
@@ -74,7 +75,7 @@ function getNoteStatusDisplay(
   }
 
   const unhandledStatus: never = status;
-  console.error("Unhandled transaction status", unhandledStatus);
+  log.error("Unhandled transaction status", unhandledStatus);
   return { icon: <PendingIcon />, message: messages.pending };
 }
 

--- a/renderer/components/OnboardingFlow/SnapshotDownloadPrompt/SnapshotDownloadPrompt.tsx
+++ b/renderer/components/OnboardingFlow/SnapshotDownloadPrompt/SnapshotDownloadPrompt.tsx
@@ -1,5 +1,6 @@
 import { Box, HStack, Heading, Progress, Text } from "@chakra-ui/react";
 import { formatDuration } from "date-fns";
+import log from "electron-log/renderer";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { defineMessages, useIntl } from "react-intl";
@@ -116,7 +117,7 @@ function DownloadProgress({ onSuccess }: { onSuccess: () => void }) {
         reset();
       },
       onError: (err) => {
-        console.log(err);
+        log.log(err);
         setError(err.message);
         increment();
       },


### PR DESCRIPTION
Cleans up a few uses of logging to use electron-log instead. Electron-log is preferred since we can save the logs to a file, and it's also nice since we can use it in the renderer.
